### PR TITLE
fix: local indexer

### DIFF
--- a/packages/engine-client/src/endpoints.ts
+++ b/packages/engine-client/src/endpoints.ts
@@ -1,5 +1,5 @@
 // Known endpoints for offchain engine
 export const ENGINE_CLIENT_ENDPOINTS = {
-  local: 'http://localhost:80/api',
+  local: 'http://localhost:80',
   testnet: 'https://test.vertexprotocol-backend.com',
 };


### PR DESCRIPTION
currently, indexer is broken locally as path resolves to `http://localhost/api/indexer?type=summary&subaccount=0x6f50c8887721bd541c8038ed9dd3def9962ae4d664656661756c740000000000` which doesn't exist.