### PR TITLE
Add address to wallet balance / allowance queries

### DIFF
--- a/packages/client/src/apis/spot/SpotQueryAPI.ts
+++ b/packages/client/src/apis/spot/SpotQueryAPI.ts
@@ -2,6 +2,7 @@ import { BigNumber } from 'ethers';
 import { BaseSpotAPI } from './BaseSpotAPI';
 import { BigDecimal, toBigDecimal } from '@vertex-protocol/utils';
 import { GetEngineMaxWithdrawableParams } from '@vertex-protocol/engine-client';
+import { GetTokenAllowanceParams, GetTokenWalletBalanceParams } from './types';
 
 export class SpotQueryAPI extends BaseSpotAPI {
   /**
@@ -15,21 +16,24 @@ export class SpotQueryAPI extends BaseSpotAPI {
   /**
    * Helper to get current token balance in the user's wallet (i.e. not in a Vertex subaccount)
    */
-  async getTokenWalletBalance(productId: number): Promise<BigNumber> {
+  async getTokenWalletBalance({
+    productId,
+    address,
+  }: GetTokenWalletBalanceParams): Promise<BigNumber> {
     const token = await this.getTokenContractForProduct(productId);
-    return token.balanceOf(this.getSignerAddress());
+    return token.balanceOf(address);
   }
 
   /**
    * Helper to get current token allowance
    */
-  async getTokenAllowance(productId: number): Promise<BigDecimal> {
+  async getTokenAllowance({
+    productId,
+    address,
+  }: GetTokenAllowanceParams): Promise<BigDecimal> {
     const token = await this.getTokenContractForProduct(productId);
     return toBigDecimal(
-      await token.allowance(
-        this.getSignerAddress(),
-        this.context.contracts.endpoint.address,
-      ),
+      await token.allowance(address, this.context.contracts.endpoint.address),
     );
   }
 }

--- a/packages/client/src/apis/spot/types.ts
+++ b/packages/client/src/apis/spot/types.ts
@@ -4,3 +4,13 @@ export interface ApproveAllowanceParams {
   productId: number;
   amount: BigNumberish;
 }
+
+export interface GetTokenWalletBalanceParams {
+  productId: number;
+  address: string;
+}
+
+export interface GetTokenAllowanceParams {
+  productId: number;
+  address: string;
+}


### PR DESCRIPTION
I noticed in the FE that there was a race condition on address switch. Because loading the `vertexClient` is async, we end up refetching the balance / allowance for the _old_ address instead of the new one, because the refetch occurs before the new vertex client is updated.