### PR TITLE
Fix leverage calculation by using notional value and applying abs()

### DIFF
--- a/packages/contracts/src/utils/subaccountInfo.ts
+++ b/packages/contracts/src/utils/subaccountInfo.ts
@@ -97,8 +97,8 @@ export function calcSubaccountLeverage(summary: SubaccountSummaryResponse) {
     }
     const balanceValue =
       balance.type === ProductEngineType.SPOT
-        ? calcSpotBalanceValue(balance)
-        : calcPerpBalanceValue(balance);
+        ? calcSpotBalanceValue(balance).abs()
+        : calcPerpBalanceNotionalValue(balance);
     return balanceValue.plus(calcLpBalanceValue(balance));
   });
   return numerator.dividedBy(unweightedHealth);


### PR DESCRIPTION
This was my bad, in my PR to add considerations for LPs, I introduced this bug which would result in negative leverage numbers