### PR TITLE
feat (rewards): add num eligible addresses field to rewards epoch response

### DIFF
--- a/packages/indexer-client/src/dataMappers.ts
+++ b/packages/indexer-client/src/dataMappers.ts
@@ -152,7 +152,7 @@ export function mapIndexerRewardEpoch(
     epoch: epoch.epoch,
     period: toBigDecimal(epoch.period),
     startTime: toBigDecimal(epoch.start_time),
-    addresses: epoch.addresses,
+    numEligibleAddresses: epoch.num_eligible_addresses,
     addressRewards: epoch.address_rewards.map(
       (reward): IndexerSubaccountRewardsForProduct => {
         return {

--- a/packages/indexer-client/src/dataMappers.ts
+++ b/packages/indexer-client/src/dataMappers.ts
@@ -152,6 +152,7 @@ export function mapIndexerRewardEpoch(
     epoch: epoch.epoch,
     period: toBigDecimal(epoch.period),
     startTime: toBigDecimal(epoch.start_time),
+    addresses: epoch.addresses,
     addressRewards: epoch.address_rewards.map(
       (reward): IndexerSubaccountRewardsForProduct => {
         return {

--- a/packages/indexer-client/src/types/clientTypes.ts
+++ b/packages/indexer-client/src/types/clientTypes.ts
@@ -99,7 +99,7 @@ export interface IndexerRewardEpoch {
   epoch: number;
   startTime: BigDecimal;
   period: BigDecimal;
-  addresses: number;
+  numEligibleAddresses: number;
   addressRewards: IndexerSubaccountRewardsForProduct[];
   globalRewards: IndexerGlobalRewardsForProduct[];
 }

--- a/packages/indexer-client/src/types/clientTypes.ts
+++ b/packages/indexer-client/src/types/clientTypes.ts
@@ -99,6 +99,7 @@ export interface IndexerRewardEpoch {
   epoch: number;
   startTime: BigDecimal;
   period: BigDecimal;
+  addresses: number;
   addressRewards: IndexerSubaccountRewardsForProduct[];
   globalRewards: IndexerGlobalRewardsForProduct[];
 }

--- a/packages/indexer-client/src/types/serverTypes.ts
+++ b/packages/indexer-client/src/types/serverTypes.ts
@@ -148,8 +148,7 @@ export interface IndexerServerRewardEpoch {
   epoch: number;
   start_time: string;
   period: string;
-  // Number of addresses
-  addresses: number;
+  num_eligible_addresses: number;
   // Per product ID
   address_rewards: IndexerServerSubaccountRewardsForProduct[];
   global_rewards: IndexerServerGlobalRewardsForProduct[];

--- a/packages/indexer-client/src/types/serverTypes.ts
+++ b/packages/indexer-client/src/types/serverTypes.ts
@@ -148,6 +148,8 @@ export interface IndexerServerRewardEpoch {
   epoch: number;
   start_time: string;
   period: string;
+  // Number of addresses
+  addresses: number;
   // Per product ID
   address_rewards: IndexerServerSubaccountRewardsForProduct[];
   global_rewards: IndexerServerGlobalRewardsForProduct[];


### PR DESCRIPTION
Adds addresses to rewards total traders. As per 
https://vertex-xwn1857.slack.com/archives/C02MP5AAYSJ/p1688407468389679?thread_ts=1687444532.795079&cid=C02MP5AAYSJ

Let me know if I need to gen docs.