### PR TITLE
Add 'tvl' to getMarketSnapshots

### DIFF
--- a/packages/indexer-client/src/IndexerBaseClient.ts
+++ b/packages/indexer-client/src/IndexerBaseClient.ts
@@ -569,6 +569,7 @@ export class IndexerBaseClient {
         timestamp: toBigDecimal(snapshot.timestamp),
         cumulativeUsers: toBigDecimal(snapshot.cumulative_users),
         dailyActiveUsers: toBigDecimal(snapshot.daily_active_users),
+        tvl: toBigDecimal(snapshot.tvl),
         borrowRates: mapValues(snapshot.borrow_rates, toBigDecimal),
         cumulativeLiquidationAmounts: mapValues(
           snapshot.cumulative_liquidation_amounts,

--- a/packages/indexer-client/src/types/clientTypes.ts
+++ b/packages/indexer-client/src/types/clientTypes.ts
@@ -388,6 +388,7 @@ export interface IndexerMarketSnapshot {
   timestamp: BigDecimal;
   cumulativeUsers: BigDecimal;
   dailyActiveUsers: BigDecimal;
+  tvl: BigDecimal;
   cumulativeVolumes: Record<number, BigDecimal>;
   cumulativeTakerFees: Record<number, BigDecimal>;
   cumulativeSequencerFees: Record<number, BigDecimal>;

--- a/packages/indexer-client/src/types/serverModelTypes.ts
+++ b/packages/indexer-client/src/types/serverModelTypes.ts
@@ -124,6 +124,7 @@ export interface IndexerServerMarketSnapshot {
   timestamp: string;
   cumulative_users: string;
   daily_active_users: string;
+  tvl: string;
   // Keyed by product ID -> decimal value in string (i.e. no decimal adjustment) necessary
   // Backend serializes hashmaps with string keys
   cumulative_volumes: Record<string, string>;


### PR DESCRIPTION
`tvl` was added to `MarketSnapshotData` a while back but SDK wasn't updated. Will need it for stats-dashboard migration.

https://github.com/vertex-protocol/vertex-core/blob/develop/vertex-utils/src/indexer.rs#L902 
