### PR TITLE
Fix RangeError on some wallets when trying to claim rewards

### DIFF
--- a/packages/client/src/apis/rewards/RewardsExecuteAPI.ts
+++ b/packages/client/src/apis/rewards/RewardsExecuteAPI.ts
@@ -177,8 +177,11 @@ export class RewardsExecuteAPI extends BaseVertexAPI {
         return params.amount;
       }
       const amountsClaimed = await airdropContract.getClaimed(address);
+
       const availableAmount = totalAmount.minus(
-        amountsClaimed[params.epoch].toString(),
+        // Some wallets seem to throw a `RangeError` here if we do amountsClaimed[params.epoch]
+        // Likely because `amountsClaimed` isn't a simple array but a proxy
+        amountsClaimed.at(params.epoch)?.toString() ?? 0,
       );
 
       return availableAmount.toFixed();


### PR DESCRIPTION
I have no idea why this happens, but this _should_ fix: https://vertex-xwn1857.slack.com/archives/C054VJ2DEFL/p1707739663393299

(For context, user resolved by using metamask)