### PR TITLE
Tighten generic typing for engine execute result

### DIFF
--- a/packages/engine-client/src/types/clientExecuteTypes.ts
+++ b/packages/engine-client/src/types/clientExecuteTypes.ts
@@ -91,6 +91,7 @@ export interface EngineExecuteRequestParamsByType {
   link_signer: EngineLinkSignerParams;
 }
 
-export type EnginePlaceOrderResult = EngineServerExecuteResult & {
-  orderParams: EIP712OrderParams;
-};
+export type EnginePlaceOrderResult =
+  EngineServerExecuteResult<'place_order'> & {
+    orderParams: EIP712OrderParams;
+  };


### PR DESCRIPTION
Fixes [this](https://github.com/vertex-protocol/vertex-web-monorepo/pull/2053#discussion_r1581786197), now result types are "tightened" to the specific request type, now we can properly access the `data` field without casting:

<img width="914" alt="image" src="https://github.com/vertex-protocol/vertex-typescript-sdk/assets/31530056/2d414ddb-ef3e-4971-a1a9-8c03fa151508">
