### PR TITLE
Cleanup: Remove getOrderDigest from EngineClient

### DIFF
--- a/apps/e2e/src/client/fullSanity.ts
+++ b/apps/e2e/src/client/fullSanity.ts
@@ -1,13 +1,14 @@
-import { RunContext } from '../utils/types';
+import { createVertexClient, PlaceOrderParams } from '@vertex-protocol/client';
 import {
   getChainIdFromSigner,
+  getOrderDigest,
   getOrderNonce,
 } from '@vertex-protocol/contracts';
-import { toBigDecimal, toFixedPoint } from '@vertex-protocol/utils';
-import { runWithContext } from '../utils/runWithContext';
-import { createVertexClient, PlaceOrderParams } from '@vertex-protocol/client';
+import { toFixedPoint } from '@vertex-protocol/utils';
 import { getExpiration } from '../utils/getExpiration';
 import { prettyPrint } from '../utils/prettyPrint';
+import { runWithContext } from '../utils/runWithContext';
+import { RunContext } from '../utils/types';
 
 async function fullSanity(context: RunContext) {
   const signer = context.getWallet();
@@ -106,11 +107,11 @@ async function fullSanity(context: RunContext) {
   const verifyingAddr =
     await vertexClient.context.engineClient.getOrderbookAddress(3);
 
-  const digest = vertexClient.context.engineClient.getOrderDigest(
-    orderResult.orderParams,
+  const digest = getOrderDigest({
+    order: orderResult.orderParams,
     verifyingAddr,
     chainId,
-  );
+  });
 
   prettyPrint('Order digest', digest);
 
@@ -131,11 +132,13 @@ async function fullSanity(context: RunContext) {
 
   prettyPrint('Place perp order result', perpOrderResult);
 
-  const perpOrderDigest = vertexClient.context.engineClient.getOrderDigest(
-    perpOrderResult.orderParams,
-    await vertexClient.context.engineClient.getOrderbookAddress(4),
+  const perpOrderDigest = getOrderDigest({
+    order: perpOrderResult.orderParams,
+    verifyingAddr: await vertexClient.context.engineClient.getOrderbookAddress(
+      4,
+    ),
     chainId,
-  );
+  });
 
   console.log(`Cancelling and placing orders in single request`);
   const cancelAndPlaceResult = await vertexClient.market.cancelAndPlace({

--- a/apps/e2e/src/client/wsSanity.ts
+++ b/apps/e2e/src/client/wsSanity.ts
@@ -1,12 +1,13 @@
-import { RunContext } from '../utils/types';
+import { createVertexClient, PlaceOrderParams } from '@vertex-protocol/client';
 import {
   getChainIdFromSigner,
+  getOrderDigest,
   getOrderNonce,
   subaccountToHex,
 } from '@vertex-protocol/contracts';
 import { nowInSeconds, toFixedPoint } from '@vertex-protocol/utils';
 import { runWithContext } from '../utils/runWithContext';
-import { createVertexClient, PlaceOrderParams } from '@vertex-protocol/client';
+import { RunContext } from '../utils/types';
 
 async function wsSanity(context: RunContext) {
   const signer = context.getWallet();
@@ -55,11 +56,11 @@ async function wsSanity(context: RunContext) {
     `Place Order WS request: ${JSON.stringify(wsPlaceOrderReq, null, 2)}`,
   );
 
-  const wsOrderDigest = vertexClient.context.engineClient.getOrderDigest(
-    wsOrder,
+  const wsOrderDigest = getOrderDigest({
+    order: wsOrder,
     verifyingAddr,
     chainId,
-  );
+  });
 
   const wsCancelOrdersReq = vertexClient.ws.execute.buildCancelOrdersMessage({
     subaccountOwner: await signer.getAddress(),

--- a/apps/e2e/src/engine-client/fullSanity.ts
+++ b/apps/e2e/src/engine-client/fullSanity.ts
@@ -1,13 +1,9 @@
-import { RunContext } from '../utils/types';
-import {
-  EngineClient,
-  EngineOrderParams,
-} from '@vertex-protocol/engine-client';
 import {
   createDeterministicLinkedSignerPrivateKey,
   depositCollateral,
   Endpoint__factory,
   getChainIdFromSigner,
+  getOrderDigest,
   getOrderNonce,
   IClearinghouse__factory,
   MockERC20__factory,
@@ -16,11 +12,16 @@ import {
   subaccountToBytes32,
   subaccountToHex,
 } from '@vertex-protocol/contracts';
+import {
+  EngineClient,
+  EngineOrderParams,
+} from '@vertex-protocol/engine-client';
 import { toBigDecimal, toFixedPoint } from '@vertex-protocol/utils';
 import { Wallet, ZeroAddress } from 'ethers';
-import { runWithContext } from '../utils/runWithContext';
 import { getExpiration } from '../utils/getExpiration';
 import { prettyPrint } from '../utils/prettyPrint';
+import { runWithContext } from '../utils/runWithContext';
+import { RunContext } from '../utils/types';
 
 async function fullSanity(context: RunContext) {
   const signer = context.getWallet();
@@ -111,11 +112,11 @@ async function fullSanity(context: RunContext) {
     order,
     nonce: getOrderNonce(),
   });
-  const orderDigest = client.getOrderDigest(
-    placeResult.orderParams,
-    orderbookAddr,
+  const orderDigest = getOrderDigest({
+    order: placeResult.orderParams,
+    verifyingAddr: orderbookAddr,
     chainId,
-  );
+  });
   prettyPrint('Done placing spot order', placeResult);
 
   const subaccountOrders = await client.getSubaccountOrders({

--- a/packages/engine-client/src/EngineExecuteClient.ts
+++ b/packages/engine-client/src/EngineExecuteClient.ts
@@ -1,5 +1,3 @@
-import { EIP712OrderParams, getOrderDigest } from '@vertex-protocol/contracts';
-import { BigNumberish } from 'ethers';
 import { EngineBaseClient, EngineClientOpts } from './EngineBaseClient';
 import { EngineExecuteBuilder } from './EngineExecuteBuilder';
 import {
@@ -97,17 +95,5 @@ export class EngineExecuteClient extends EngineBaseClient {
       'link_signer',
       await this.payloadBuilder.buildLinkSignerPayload(params),
     );
-  }
-
-  getOrderDigest(
-    order: EIP712OrderParams,
-    verifyingAddr: string,
-    chainId: BigNumberish,
-  ): string {
-    return getOrderDigest({
-      chainId,
-      order,
-      verifyingAddr,
-    });
   }
 }


### PR DESCRIPTION
We pretty much just forwarded arguments to the same util function, so was thinking that we don't need this on the client itself so that we have one "source of truth" function for computing digest