### PR TITLE
Rename chainenv to be arbitrum-agnostic

### DIFF
--- a/apps/e2e/src/indexer-client/fullSanity.ts
+++ b/apps/e2e/src/indexer-client/fullSanity.ts
@@ -86,7 +86,7 @@ async function fullSanity(context: RunContext) {
 
   if (
     context.env.chainEnv === 'blastTestnet' ||
-    context.env.chainEnv === 'blastMainnet'
+    context.env.chainEnv === 'blast'
   ) {
     const blastPoints = await client.getBlastPoints({
       address: subaccount.subaccountOwner,

--- a/apps/e2e/src/utils/env.ts
+++ b/apps/e2e/src/utils/env.ts
@@ -2,7 +2,8 @@ import 'dotenv/config';
 import { ChainEnv } from '@vertex-protocol/contracts';
 import { Env } from './types';
 
-const chainEnv: ChainEnv = (process.env.CHAIN_ENV as ChainEnv) ?? 'testnet';
+const chainEnv: ChainEnv =
+  (process.env.CHAIN_ENV as ChainEnv) ?? 'arbitrumTestnet';
 const privateKey = process.env.PRIVATE_KEY ?? '';
 
 export const env: Env = {

--- a/apps/e2e/src/utils/getProvider.ts
+++ b/apps/e2e/src/utils/getProvider.ts
@@ -5,12 +5,12 @@ export function getProvider(chainEnv: ChainEnv): Provider {
   switch (chainEnv) {
     case 'local':
       return new JsonRpcProvider();
-    case 'testnet':
+    case 'arbitrumTestnet':
       return new JsonRpcProvider('https://sepolia-rollup.arbitrum.io/rpc', {
         name: 'arbitrum-sepolia',
         chainId: 421614,
       });
-    case 'mainnet':
+    case 'arbitrum':
       return new JsonRpcProvider('https://arb1.arbitrum.io/rpc', {
         name: 'arbitrum-one',
         chainId: 42161,
@@ -20,7 +20,7 @@ export function getProvider(chainEnv: ChainEnv): Provider {
         name: 'blast-sepolia',
         chainId: 1685877734,
       });
-    case 'blastMainnet':
+    case 'blast':
       return new JsonRpcProvider('https://rpc.blast.io', {
         name: 'blast',
         chainId: 81457,

--- a/packages/client/src/context.ts
+++ b/packages/client/src/context.ts
@@ -81,20 +81,20 @@ export async function createClientContext(
     indexerEndpoint,
     triggerEndpoint,
   } = ((): VertexClientContextOpts => {
-    if (opts === 'testnet') {
+    if (opts === 'arbitrumTestnet') {
       return {
-        contractAddresses: VERTEX_DEPLOYMENTS.testnet,
-        engineEndpoint: ENGINE_CLIENT_ENDPOINTS.testnet,
-        indexerEndpoint: INDEXER_CLIENT_ENDPOINTS.testnet,
-        triggerEndpoint: TRIGGER_CLIENT_ENDPOINTS.testnet,
+        contractAddresses: VERTEX_DEPLOYMENTS.arbitrumTestnet,
+        engineEndpoint: ENGINE_CLIENT_ENDPOINTS.arbitrumTestnet,
+        indexerEndpoint: INDEXER_CLIENT_ENDPOINTS.arbitrumTestnet,
+        triggerEndpoint: TRIGGER_CLIENT_ENDPOINTS.arbitrumTestnet,
       };
     }
-    if (opts === 'mainnet') {
+    if (opts === 'arbitrum') {
       return {
-        contractAddresses: VERTEX_DEPLOYMENTS.mainnet,
-        engineEndpoint: ENGINE_CLIENT_ENDPOINTS.mainnet,
-        indexerEndpoint: INDEXER_CLIENT_ENDPOINTS.mainnet,
-        triggerEndpoint: TRIGGER_CLIENT_ENDPOINTS.mainnet,
+        contractAddresses: VERTEX_DEPLOYMENTS.arbitrum,
+        engineEndpoint: ENGINE_CLIENT_ENDPOINTS.arbitrum,
+        indexerEndpoint: INDEXER_CLIENT_ENDPOINTS.arbitrum,
+        triggerEndpoint: TRIGGER_CLIENT_ENDPOINTS.arbitrum,
       };
     }
     if (opts === 'blastTestnet') {
@@ -105,12 +105,12 @@ export async function createClientContext(
         triggerEndpoint: TRIGGER_CLIENT_ENDPOINTS.blastTestnet,
       };
     }
-    if (opts === 'blastMainnet') {
+    if (opts === 'blast') {
       return {
-        contractAddresses: VERTEX_DEPLOYMENTS.blastMainnet,
-        engineEndpoint: ENGINE_CLIENT_ENDPOINTS.blastMainnet,
-        indexerEndpoint: INDEXER_CLIENT_ENDPOINTS.blastMainnet,
-        triggerEndpoint: TRIGGER_CLIENT_ENDPOINTS.blastMainnet,
+        contractAddresses: VERTEX_DEPLOYMENTS.blast,
+        engineEndpoint: ENGINE_CLIENT_ENDPOINTS.blast,
+        indexerEndpoint: INDEXER_CLIENT_ENDPOINTS.blast,
+        triggerEndpoint: TRIGGER_CLIENT_ENDPOINTS.blast,
       };
     }
     if (opts === 'mantleTestnet') {

--- a/packages/contracts/src/common/deployments.ts
+++ b/packages/contracts/src/common/deployments.ts
@@ -2,15 +2,15 @@ import ArbitrumOneCoreDeployment from './deployments/core/deployment.arbitrumOne
 import ArbitrumSepoliaCoreDeployment from './deployments/core/deployment.arbitrumSepolia.json';
 import BlastMainnetCoreDeployment from './deployments/core/deployment.blastMainnet.json';
 import BlastSepoliaCoreDeployment from './deployments/core/deployment.blastSepolia.json';
-import MantleSepoliaCoreDeployment from './deployments/core/deployment.mantleSepolia.json';
 import LocalCoreDeployment from './deployments/core/deployment.localhost.json';
+import MantleSepoliaCoreDeployment from './deployments/core/deployment.mantleSepolia.json';
 
 import ArbitrumOneLbaDeployment from './deployments/vrtx/deployment.arbitrumOne.json';
 import ArbitrumSepoliaLbaDeployment from './deployments/vrtx/deployment.arbitrumSepolia.json';
 import BlastMainnetLbaDeployment from './deployments/vrtx/deployment.blastMainnet.json';
 import BlastSepoliaLbaDeployment from './deployments/vrtx/deployment.blastSepolia.json';
-import MantleSepoliaLbaDeployment from './deployments/vrtx/deployment.mantleSepolia.json';
 import LocalLbaDeployment from './deployments/vrtx/deployment.localhost.json';
+import MantleSepoliaLbaDeployment from './deployments/vrtx/deployment.mantleSepolia.json';
 
 import { ChainEnv } from './types';
 import { VertexContracts } from './vertexContracts';
@@ -27,15 +27,15 @@ export const VERTEX_DEPLOYMENTS: Record<ChainEnv, VertexDeploymentAddresses> = {
     ...BlastSepoliaLbaDeployment,
     ...BlastSepoliaCoreDeployment,
   },
-  testnet: {
+  arbitrumTestnet: {
     ...ArbitrumSepoliaCoreDeployment,
     ...ArbitrumSepoliaLbaDeployment,
   },
-  mainnet: {
+  arbitrum: {
     ...ArbitrumOneLbaDeployment,
     ...ArbitrumOneCoreDeployment,
   },
-  blastMainnet: {
+  blast: {
     ...BlastMainnetLbaDeployment,
     ...BlastMainnetCoreDeployment,
   },

--- a/packages/contracts/src/common/types/ChainEnv.ts
+++ b/packages/contracts/src/common/types/ChainEnv.ts
@@ -1,7 +1,7 @@
 export type ChainEnv =
   | 'local'
-  | 'testnet'
-  | 'mainnet'
+  | 'arbitrumTestnet'
+  | 'arbitrum'
   | 'blastTestnet'
-  | 'blastMainnet'
+  | 'blast'
   | 'mantleTestnet';

--- a/packages/engine-client/src/endpoints.ts
+++ b/packages/engine-client/src/endpoints.ts
@@ -2,28 +2,29 @@ import { ChainEnv } from '@vertex-protocol/contracts';
 
 export const ENGINE_CLIENT_ENDPOINTS: Record<ChainEnv, string> = {
   local: 'http://localhost:80',
-  testnet: 'https://gateway.sepolia-test.vertexprotocol.com/v1',
+  arbitrumTestnet: 'https://gateway.sepolia-test.vertexprotocol.com/v1',
   blastTestnet: 'https://gateway.blast-test.vertexprotocol.com/v1',
-  mainnet: 'https://gateway.prod.vertexprotocol.com/v1',
-  blastMainnet: 'https://gateway.blast-prod.vertexprotocol.com/v1',
+  arbitrum: 'https://gateway.prod.vertexprotocol.com/v1',
+  blast: 'https://gateway.blast-prod.vertexprotocol.com/v1',
   mantleTestnet: 'https://gateway.mantle-test.vertexprotocol.com/v1',
 };
 
 export const ENGINE_WS_CLIENT_ENDPOINTS: Record<ChainEnv, string> = {
   local: 'ws://localhost:80',
-  testnet: 'wss://gateway.sepolia-test.vertexprotocol.com/v1/ws',
+  arbitrumTestnet: 'wss://gateway.sepolia-test.vertexprotocol.com/v1/ws',
   blastTestnet: 'wss://gateway.blast-test.vertexprotocol.com/v1/ws',
-  mainnet: 'wss://gateway.prod.vertexprotocol.com/v1/ws',
-  blastMainnet: 'wss://gateway.blast-prod.vertexprotocol.com/v1/ws',
+  arbitrum: 'wss://gateway.prod.vertexprotocol.com/v1/ws',
+  blast: 'wss://gateway.blast-prod.vertexprotocol.com/v1/ws',
   mantleTestnet: 'wss://gateway.mantle-test.vertexprotocol.com/v1/ws',
 };
 
 export const ENGINE_WS_SUBSCRIPTION_CLIENT_ENDPOINTS: Record<ChainEnv, string> =
   {
     local: 'ws://localhost:80',
-    testnet: 'wss://gateway.sepolia-test.vertexprotocol.com/v1/subscribe',
+    arbitrumTestnet:
+      'wss://gateway.sepolia-test.vertexprotocol.com/v1/subscribe',
     blastTestnet: 'wss://gateway.blast-test.vertexprotocol.com/v1/subscribe',
-    mainnet: 'wss://gateway.prod.vertexprotocol.com/v1/subscribe',
-    blastMainnet: 'wss://gateway.blast-prod.vertexprotocol.com/v1/subscribe',
+    arbitrum: 'wss://gateway.prod.vertexprotocol.com/v1/subscribe',
+    blast: 'wss://gateway.blast-prod.vertexprotocol.com/v1/subscribe',
     mantleTestnet: 'wss://gateway.mantle-test.vertexprotocol.com/v1/subscribe',
   };

--- a/packages/indexer-client/src/endpoints.ts
+++ b/packages/indexer-client/src/endpoints.ts
@@ -2,9 +2,9 @@ import { ChainEnv } from '@vertex-protocol/contracts';
 
 export const INDEXER_CLIENT_ENDPOINTS: Record<ChainEnv, string> = {
   local: 'http://localhost:8000/indexer',
-  testnet: 'https://archive.sepolia-test.vertexprotocol.com/v1',
+  arbitrumTestnet: 'https://archive.sepolia-test.vertexprotocol.com/v1',
   blastTestnet: 'https://archive.blast-test.vertexprotocol.com/v1',
-  mainnet: 'https://archive.prod.vertexprotocol.com/v1',
-  blastMainnet: 'https://archive.blast-prod.vertexprotocol.com/v1',
+  arbitrum: 'https://archive.prod.vertexprotocol.com/v1',
+  blast: 'https://archive.blast-prod.vertexprotocol.com/v1',
   mantleTestnet: 'https://archive.mantle-test.vertexprotocol.com/v1',
 };

--- a/packages/trigger-client/src/endpoints.ts
+++ b/packages/trigger-client/src/endpoints.ts
@@ -2,9 +2,9 @@ import { ChainEnv } from '@vertex-protocol/contracts';
 
 export const TRIGGER_CLIENT_ENDPOINTS: Record<ChainEnv, string> = {
   local: 'http://localhost:80/trigger',
-  testnet: 'https://trigger.sepolia-test.vertexprotocol.com/v1',
+  arbitrumTestnet: 'https://trigger.sepolia-test.vertexprotocol.com/v1',
   blastTestnet: 'https://trigger.blast-test.vertexprotocol.com/v1',
-  mainnet: 'https://trigger.prod.vertexprotocol.com/v1',
-  blastMainnet: 'https://trigger.blast-prod.vertexprotocol.com/v1',
+  arbitrum: 'https://trigger.prod.vertexprotocol.com/v1',
+  blast: 'https://trigger.blast-prod.vertexprotocol.com/v1',
   mantleTestnet: 'https://trigger.mantle-test.vertexprotocol.com/v1',
 };


### PR DESCRIPTION
This will also help with chain switching on the FE, ideally we have some sort of query parameter that lets us point users to a specific chain on-load. For example: `app.vertexprotocol.com/portfolio/overview?chain=arbitrum` 

Also removed the `Mainnet` postfix. This is to align more with other APIs (ex. [Viem](https://github.com/wagmi-dev/viem/tree/main/src/chains/index.ts) doesn't have mainnet postfixes) and to make the URLs a bit nicer