### PR TITLE
Remove failure result from execute promises as errors are thrown and not returned

### DIFF
--- a/apps/e2e/src/engine-client/fullSanity.ts
+++ b/apps/e2e/src/engine-client/fullSanity.ts
@@ -119,6 +119,12 @@ async function fullSanity(context: RunContext) {
   });
   prettyPrint('Done placing spot order', placeResult);
 
+  if (orderDigest !== placeResult.data.digest) {
+    throw Error(
+      `Computed and returned order digests do not match. Computed: ${orderDigest}. Returned: ${placeResult.data.digest}`,
+    );
+  }
+
   const subaccountOrders = await client.getSubaccountOrders({
     productId: 2,
     subaccountName: 'default',

--- a/packages/engine-client/src/EngineBaseClient.ts
+++ b/packages/engine-client/src/EngineBaseClient.ts
@@ -9,6 +9,7 @@ import {
   EngineServerExecuteRequestByType,
   EngineServerExecuteRequestType,
   EngineServerExecuteResult,
+  EngineServerExecuteSuccessResult,
   EngineServerQueryRequest,
   EngineServerQueryRequestByType,
   EngineServerQueryRequestType,
@@ -128,7 +129,8 @@ export class EngineBaseClient {
   }
 
   /**
-   * POSTs an execute message to the engine
+   * POSTs an execute message to the engine and returns the successful response. Throws the failure response wrapped
+   * in an EngineServerFailureError on failure.
    *
    * @param requestType
    * @param params
@@ -137,7 +139,7 @@ export class EngineBaseClient {
   public async execute<TRequestType extends EngineServerExecuteRequestType>(
     requestType: TRequestType,
     params: EngineServerExecuteRequestByType[TRequestType],
-  ): Promise<EngineServerExecuteResult<TRequestType>> {
+  ): Promise<EngineServerExecuteSuccessResult<TRequestType>> {
     const reqBody = this.getExecuteRequest(requestType, params);
     const response = await this.axiosInstance.post<
       EngineServerExecuteResult<TRequestType>
@@ -146,7 +148,8 @@ export class EngineBaseClient {
     this.checkResponseStatus(response);
     this.checkServerStatus(response);
 
-    return response.data;
+    // checkServerStatus catches the failure result and throws the error, so the cast to the success response is acceptable here
+    return response.data as EngineServerExecuteSuccessResult<TRequestType>;
   }
 
   /**

--- a/packages/engine-client/src/types/clientExecuteTypes.ts
+++ b/packages/engine-client/src/types/clientExecuteTypes.ts
@@ -9,7 +9,7 @@ import {
   EIP712WithdrawCollateralParams,
 } from '@vertex-protocol/contracts';
 import { BigNumberish } from 'ethers';
-import { EngineServerExecuteResult } from './serverExecuteTypes';
+import { EngineServerExecuteSuccessResult } from './serverExecuteTypes';
 
 /**
  * Either verifying address or signature must be provided;
@@ -92,6 +92,6 @@ export interface EngineExecuteRequestParamsByType {
 }
 
 export type EnginePlaceOrderResult =
-  EngineServerExecuteResult<'place_order'> & {
+  EngineServerExecuteSuccessResult<'place_order'> & {
     orderParams: EIP712OrderParams;
   };

--- a/packages/trigger-client/src/TriggerClient.ts
+++ b/packages/trigger-client/src/TriggerClient.ts
@@ -24,6 +24,7 @@ import {
   TriggerServerExecuteRequestByType,
   TriggerServerExecuteRequestType,
   TriggerServerExecuteResult,
+  TriggerServerExecuteSuccessResult,
   TriggerServerQueryRequestByType,
   TriggerServerQueryRequestType,
   TriggerServerQueryResponse,
@@ -208,22 +209,29 @@ export class TriggerClient {
     });
   }
 
+  /**
+   * POSTs an execute message to the trigger service and returns the successful response. Throws the failure response wrapped
+   * in an TriggerServerFailureError on failure.
+   *
+   * @param requestType
+   * @param params
+   */
   protected async execute<TRequestType extends TriggerServerExecuteRequestType>(
     requestType: TRequestType,
     params: TriggerServerExecuteRequestByType[TRequestType],
-  ): Promise<TriggerServerExecuteResult> {
+  ): Promise<TriggerServerExecuteSuccessResult<TRequestType>> {
     const reqBody = {
       [requestType]: params,
     };
-    const response = await this.axiosInstance.post<TriggerServerExecuteResult>(
-      `${this.opts.url}/execute`,
-      reqBody,
-    );
+    const response = await this.axiosInstance.post<
+      TriggerServerExecuteResult<TRequestType>
+    >(`${this.opts.url}/execute`, reqBody);
 
     this.checkResponseStatus(response);
     this.checkServerStatus(response);
 
-    return response.data;
+    // checkServerStatus catches the failure result and throws the error, so the cast to the success response is acceptable here
+    return response.data as TriggerServerExecuteSuccessResult<TRequestType>;
   }
 
   protected async query<TRequestType extends TriggerServerQueryRequestType>(

--- a/packages/trigger-client/src/types/serverExecuteTypes.ts
+++ b/packages/trigger-client/src/types/serverExecuteTypes.ts
@@ -1,7 +1,8 @@
 import { EIP712OrderValues } from '@vertex-protocol/contracts';
 import {
+  EngineServerExecuteFailureResult,
   EngineServerExecuteRequestByType,
-  EngineServerExecuteResult,
+  EngineServerExecuteSuccessResult,
 } from '@vertex-protocol/engine-client';
 
 export type TriggerServerTriggerCriteria =
@@ -46,4 +47,10 @@ export interface TriggerServerExecuteRequestByType {
 export type TriggerServerExecuteRequestType =
   keyof TriggerServerExecuteRequestByType;
 
-export type TriggerServerExecuteResult = EngineServerExecuteResult;
+export type TriggerServerExecuteSuccessResult<
+  T extends TriggerServerExecuteRequestType = TriggerServerExecuteRequestType,
+> = EngineServerExecuteSuccessResult<T>;
+
+export type TriggerServerExecuteResult<
+  T extends TriggerServerExecuteRequestType = TriggerServerExecuteRequestType,
+> = TriggerServerExecuteSuccessResult<T> | EngineServerExecuteFailureResult;


### PR DESCRIPTION
Title is self-explanatory, we never actually return the failure result as it gets thrown