### PR TITLE
Patch wallet client hook

### DIFF
--- a/packages/react-client/src/context/evm/hooks/usePrimaryChainWalletClient.ts
+++ b/packages/react-client/src/context/evm/hooks/usePrimaryChainWalletClient.ts
@@ -1,12 +1,11 @@
-import { useWalletClient } from 'wagmi';
+import { useWalletClient, UseWalletClientParameters } from 'wagmi';
 import { usePrimaryChainId } from './usePrimaryChainId';
 
-export function usePrimaryChainWalletClient() {
+export function usePrimaryChainWalletClient(
+  params?: UseWalletClientParameters,
+) {
   const primaryChainId = usePrimaryChainId();
-
-  const { data } = useWalletClient({
-    chainId: primaryChainId,
-  });
+  const { data } = useWalletClient({ chainId: primaryChainId, ...params });
 
   return data;
 }


### PR DESCRIPTION
The hook is not properly initialize without the other params. This PR adds the other params to the `useWalletClient` hook.