### PR TITLE
Add maxTimestampInclusive to Archive Subaccount Pagination Queries

### DIFF
--- a/apps/e2e/src/indexer-client/fullSanity.ts
+++ b/apps/e2e/src/indexer-client/fullSanity.ts
@@ -235,7 +235,7 @@ async function fullSanity(context: RunContext) {
 
   const withdrawEvents = await client.getPaginatedSubaccountCollateralEvents({
     limit: 1,
-    startCursor: '507204',
+    maxTimestampInclusive: nowInSeconds() - TimeInSeconds.DAY,
     subaccountName: subaccount.subaccountName,
     subaccountOwner: subaccount.subaccountOwner,
     eventTypes: ['withdraw_collateral'],

--- a/packages/indexer-client/src/IndexerClient.ts
+++ b/packages/indexer-client/src/IndexerClient.ts
@@ -41,6 +41,7 @@ export class IndexerClient extends IndexerBaseClient {
   ): Promise<GetIndexerSubaccountMatchEventsResponse> {
     const {
       startCursor,
+      maxTimestampInclusive,
       limit: requestedLimit,
       subaccountName,
       subaccountOwner,
@@ -49,6 +50,7 @@ export class IndexerClient extends IndexerBaseClient {
     const limit = requestedLimit + 1;
     const events = await this.getMatchEvents({
       startCursor,
+      maxTimestampInclusive,
       limit,
       subaccount: { subaccountName, subaccountOwner },
       productIds: params.productIds,
@@ -62,6 +64,7 @@ export class IndexerClient extends IndexerBaseClient {
   ): Promise<GetIndexerSubaccountLpEventsResponse> {
     const {
       startCursor,
+      maxTimestampInclusive,
       limit: requestedLimit,
       subaccountName,
       subaccountOwner,
@@ -72,6 +75,7 @@ export class IndexerClient extends IndexerBaseClient {
     const limit = requestedLimit + 1;
     const baseResponse = await this.getEvents({
       startCursor,
+      maxTimestampInclusive,
       eventTypes: ['mint_lp', 'burn_lp'],
       limit: {
         type: 'txs',
@@ -146,6 +150,7 @@ export class IndexerClient extends IndexerBaseClient {
   ): Promise<GetIndexerSubaccountCollateralEventsResponse> {
     const {
       startCursor,
+      maxTimestampInclusive,
       limit: requestedLimit,
       subaccountName,
       subaccountOwner,
@@ -154,6 +159,7 @@ export class IndexerClient extends IndexerBaseClient {
     const limit = requestedLimit + 1;
     const baseResponse = await this.getEvents({
       startCursor,
+      maxTimestampInclusive,
       eventTypes: params.eventTypes ?? [
         'deposit_collateral',
         'withdraw_collateral',
@@ -189,6 +195,7 @@ export class IndexerClient extends IndexerBaseClient {
   ): Promise<GetIndexerPaginatedOrdersResponse> {
     const {
       startCursor,
+      maxTimestampInclusive,
       limit: requestedLimit,
       subaccountName,
       subaccountOwner,
@@ -198,6 +205,7 @@ export class IndexerClient extends IndexerBaseClient {
     const limit = requestedLimit + 1;
     const baseResponse = await this.getOrders({
       startCursor,
+      maxTimestampInclusive,
       subaccount: { subaccountName, subaccountOwner },
       limit,
       productIds,
@@ -220,6 +228,7 @@ export class IndexerClient extends IndexerBaseClient {
   ): Promise<GetIndexerSubaccountSettlementEventsResponse> {
     const {
       startCursor,
+      maxTimestampInclusive,
       limit: requestedLimit,
       subaccountName,
       subaccountOwner,
@@ -229,6 +238,7 @@ export class IndexerClient extends IndexerBaseClient {
     const limit = requestedLimit + 1;
     const baseResponse = await this.getEvents({
       startCursor,
+      maxTimestampInclusive,
       eventTypes: ['settle_pnl'],
       limit: {
         type: 'txs',
@@ -266,6 +276,7 @@ export class IndexerClient extends IndexerBaseClient {
   ): Promise<GetIndexerSubaccountLiquidationEventsResponse> {
     const {
       startCursor,
+      maxTimestampInclusive,
       limit: requestedLimit,
       subaccountName,
       subaccountOwner,
@@ -278,6 +289,7 @@ export class IndexerClient extends IndexerBaseClient {
     const limit = requestedLimit + 1;
     const baseResponse = await this.getEvents({
       startCursor,
+      maxTimestampInclusive,
       eventTypes: ['liquidate_subaccount'],
       limit: {
         type: 'txs',

--- a/packages/indexer-client/src/types/paginatedEventsTypes.ts
+++ b/packages/indexer-client/src/types/paginatedEventsTypes.ts
@@ -29,7 +29,14 @@ export interface IndexerPaginationMeta {
 
 export type WithPaginationMeta = { meta: IndexerPaginationMeta };
 
-type BaseSubaccountPaginationParams = Subaccount & IndexerPaginationParams;
+type BaseSubaccountPaginationParams = Subaccount &
+  IndexerPaginationParams & {
+    /**
+     * If provided, only events with a timestamp in seconds <= this value will be returned
+     * Specifying `startCursor` will supercede this value
+     */
+    maxTimestampInclusive?: number;
+  };
 
 export interface BaseIndexerPaginatedEvent {
   timestamp: BigDecimal;
@@ -186,9 +193,11 @@ export type GetIndexerSubaccountSettlementEventsResponse =
  * Interest / Funding
  */
 
-export type GetIndexerSubaccountInterestFundingPaymentsParams =
-  BaseSubaccountPaginationParams &
-    Pick<GetIndexerInterestFundingPaymentsParams, 'productIds' | 'startCursor'>;
+export type GetIndexerSubaccountInterestFundingPaymentsParams = Omit<
+  BaseSubaccountPaginationParams,
+  'maxTimestampInclusive'
+> &
+  Pick<GetIndexerInterestFundingPaymentsParams, 'productIds' | 'startCursor'>;
 
 export interface GetIndexerPaginatedInterestFundingPaymentsResponse
   extends GetIndexerInterestFundingPaymentsResponse {


### PR DESCRIPTION
Propagates `maxTimestampInclusive` through subaccount pagination queries. We need this for export history work on the FE