### PR TITLE
Add edge queries

### DIFF
--- a/packages/client/src/apis/market/MarketQueryAPI.ts
+++ b/packages/client/src/apis/market/MarketQueryAPI.ts
@@ -129,6 +129,15 @@ export class MarketQueryAPI extends BaseVertexAPI {
   }
 
   /**
+   * Historical candlesticks from Edge, use getLatestMarketPrice for the latest orderbook prices
+   *
+   * @param params
+   */
+  async getEdgeCandlesticks(params: GetIndexerCandlesticksParams) {
+    return this.context.indexerClient.getEdgeCandlesticks(params);
+  }
+
+  /**
    * Retrieves the latest off-chain orderbook price from the engine
    *
    * @param params
@@ -182,6 +191,15 @@ export class MarketQueryAPI extends BaseVertexAPI {
    */
   async getMarketSnapshots(params: GetIndexerMarketSnapshotsParams) {
     return this.context.indexerClient.getMarketSnapshots(params);
+  }
+
+  /**
+   * Retrieves the historical snapshots for a market from Edge
+   *
+   * @param params
+   */
+  async getEdgeMarketSnapshots(params: GetIndexerMarketSnapshotsParams) {
+    return this.context.indexerClient.getEdgeMarketSnapshots(params);
   }
 
   /**

--- a/packages/client/src/apis/market/MarketQueryAPI.ts
+++ b/packages/client/src/apis/market/MarketQueryAPI.ts
@@ -14,6 +14,8 @@ import {
 } from '@vertex-protocol/engine-client';
 import {
   GetIndexerCandlesticksParams,
+  GetIndexerEdgeCandlesticksParams,
+  GetIndexerEdgeMarketSnapshotsParams,
   GetIndexerFundingRateParams,
   GetIndexerMarketSnapshotsParams,
   GetIndexerMultiProductFundingRatesParams,
@@ -133,7 +135,7 @@ export class MarketQueryAPI extends BaseVertexAPI {
    *
    * @param params
    */
-  async getEdgeCandlesticks(params: GetIndexerCandlesticksParams) {
+  async getEdgeCandlesticks(params: GetIndexerEdgeCandlesticksParams) {
     return this.context.indexerClient.getEdgeCandlesticks(params);
   }
 
@@ -198,7 +200,7 @@ export class MarketQueryAPI extends BaseVertexAPI {
    *
    * @param params
    */
-  async getEdgeMarketSnapshots(params: GetIndexerMarketSnapshotsParams) {
+  async getEdgeMarketSnapshots(params: GetIndexerEdgeMarketSnapshotsParams) {
     return this.context.indexerClient.getEdgeMarketSnapshots(params);
   }
 

--- a/packages/indexer-client/src/IndexerBaseClient.ts
+++ b/packages/indexer-client/src/IndexerBaseClient.ts
@@ -36,7 +36,6 @@ import {
   mapIndexerServerProduct,
 } from './dataMappers';
 import {
-  Candlestick,
   GetIndexerBlastPointsParams,
   GetIndexerBlastPointsResponse,
   GetIndexerBlitzInitialDropConditionsParams,
@@ -107,7 +106,6 @@ import {
   GetIndexerVrtxTokenInfoParams,
   GetIndexerVrtxTokenInfoResponse,
   IndexerEventWithTx,
-  IndexerMarketSnapshot,
   IndexerMatchEvent,
   IndexerOraclePrice,
   IndexerServerEventsParams,
@@ -680,7 +678,6 @@ export class IndexerBaseClient {
         max_time: params.maxTimeInclusive?.toString(),
         count: params.limit,
       },
-      product_ids: params.productIds,
     });
 
     return mapValues(baseResponse.snapshots, (snapshots) =>

--- a/packages/indexer-client/src/IndexerBaseClient.ts
+++ b/packages/indexer-client/src/IndexerBaseClient.ts
@@ -18,6 +18,7 @@ import {
 } from '@vertex-protocol/utils';
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import {
+  mapIndexerCandlesticks,
   mapIndexerEvent,
   mapIndexerEventWithTx,
   mapIndexerFoundationTakerRewardsWeek,
@@ -26,6 +27,7 @@ import {
   mapIndexerLeaderboardPosition,
   mapIndexerLeaderboardRegistration,
   mapIndexerMakerStatistics,
+  mapIndexerMarketSnapshot,
   mapIndexerMatchEventBalances,
   mapIndexerOrder,
   mapIndexerPerpPrices,
@@ -49,6 +51,10 @@ import {
   GetIndexerClaimFoundationRewardsMerkleProofsResponse,
   GetIndexerClaimVrtxMerkleProofsParams,
   GetIndexerClaimVrtxMerkleProofsResponse,
+  GetIndexerEdgeCandlesticksParams,
+  GetIndexerEdgeCandlesticksResponse,
+  GetIndexerEdgeMarketSnapshotResponse,
+  GetIndexerEdgeMarketSnapshotsParams,
   GetIndexerEventsParams,
   GetIndexerEventsResponse,
   GetIndexerFastWithdrawalSignatureParams,
@@ -379,16 +385,24 @@ export class IndexerBaseClient {
       granularity: params.period,
     });
 
-    return baseResponse.candlesticks.map((candlestick): Candlestick => {
-      return {
-        close: fromX18(candlestick.close_x18),
-        high: fromX18(candlestick.high_x18),
-        low: fromX18(candlestick.low_x18),
-        open: fromX18(candlestick.open_x18),
-        time: toBigDecimal(candlestick.timestamp),
-        volume: toBigDecimal(candlestick.volume),
-      };
+    return baseResponse.candlesticks.map(mapIndexerCandlesticks);
+  }
+
+  /**
+   * Retrieves candlesticks for a product from Edge
+   * @param params
+   */
+  async getEdgeCandlesticks(
+    params: GetIndexerEdgeCandlesticksParams,
+  ): Promise<GetIndexerEdgeCandlesticksResponse> {
+    const baseResponse = await this.query('edge_candlesticks', {
+      product_id: params.productId,
+      max_time: params.maxTimeInclusive,
+      limit: params.limit,
+      granularity: params.period,
     });
+
+    return baseResponse.candlesticks.map(mapIndexerCandlesticks);
   }
 
   /**
@@ -650,47 +664,28 @@ export class IndexerBaseClient {
       product_ids: params.productIds,
     });
 
-    return baseResponse.snapshots.map((snapshot): IndexerMarketSnapshot => {
-      return {
-        timestamp: toBigDecimal(snapshot.timestamp),
-        cumulativeUsers: toBigDecimal(snapshot.cumulative_users),
-        dailyActiveUsers: toBigDecimal(snapshot.daily_active_users),
-        tvl: toBigDecimal(snapshot.tvl),
-        borrowRates: mapValues(snapshot.borrow_rates, fromX18),
-        cumulativeLiquidationAmounts: mapValues(
-          snapshot.cumulative_liquidation_amounts,
-          toBigDecimal,
-        ),
-        cumulativeMakerFees: mapValues(
-          snapshot.cumulative_maker_fees,
-          toBigDecimal,
-        ),
-        cumulativeSequencerFees: mapValues(
-          snapshot.cumulative_sequencer_fees,
-          toBigDecimal,
-        ),
-        cumulativeTakerFees: mapValues(
-          snapshot.cumulative_taker_fees,
-          toBigDecimal,
-        ),
-        cumulativeTrades: mapValues(snapshot.cumulative_trades, toBigDecimal),
-        cumulativeVolumes: mapValues(snapshot.cumulative_volumes, toBigDecimal),
-        depositRates: mapValues(snapshot.deposit_rates, fromX18),
-        fundingRates: mapValues(snapshot.funding_rates, fromX18),
-        openInterests: mapValues(snapshot.open_interests, fromX18),
-        totalBorrows: mapValues(snapshot.total_borrows, toBigDecimal),
-        totalDeposits: mapValues(snapshot.total_deposits, toBigDecimal),
-        cumulativeTradeSizes: mapValues(
-          snapshot.cumulative_trade_sizes,
-          toBigDecimal,
-        ),
-        cumulativeInflows: mapValues(snapshot.cumulative_inflows, toBigDecimal),
-        cumulativeOutflows: mapValues(
-          snapshot.cumulative_outflows,
-          toBigDecimal,
-        ),
-      };
+    return baseResponse.snapshots.map(mapIndexerMarketSnapshot);
+  }
+
+  /**
+   * Retrieve historical market snapshots from Edge
+   * @param params
+   */
+  async getEdgeMarketSnapshots(
+    params: GetIndexerEdgeMarketSnapshotsParams,
+  ): Promise<GetIndexerEdgeMarketSnapshotResponse> {
+    const baseResponse = await this.query('edge_market_snapshots', {
+      interval: {
+        granularity: params.granularity,
+        max_time: params.maxTimeInclusive?.toString(),
+        count: params.limit,
+      },
+      product_ids: params.productIds,
     });
+
+    return mapValues(baseResponse.snapshots, (snapshots) =>
+      snapshots.map(mapIndexerMarketSnapshot),
+    );
   }
 
   /**

--- a/packages/indexer-client/src/dataMappers.ts
+++ b/packages/indexer-client/src/dataMappers.ts
@@ -383,7 +383,7 @@ export function mapIndexerMarketSnapshot(
     cumulativeVolumes: mapValues(snapshot.cumulative_volumes, toBigDecimal),
     depositRates: mapValues(snapshot.deposit_rates, fromX18),
     fundingRates: mapValues(snapshot.funding_rates, fromX18),
-    openInterests: mapValues(snapshot.open_interests, fromX18),
+    openInterestsQuote: mapValues(snapshot.open_interests, fromX18),
     totalBorrows: mapValues(snapshot.total_borrows, toBigDecimal),
     totalDeposits: mapValues(snapshot.total_deposits, toBigDecimal),
     cumulativeTradeSizes: mapValues(

--- a/packages/indexer-client/src/dataMappers.ts
+++ b/packages/indexer-client/src/dataMappers.ts
@@ -11,8 +11,9 @@ import {
   mapEngineServerPerpProduct,
   mapEngineServerSpotProduct,
 } from '@vertex-protocol/engine-client';
-import { fromX18, toBigDecimal } from '@vertex-protocol/utils';
+import { fromX18, mapValues, toBigDecimal } from '@vertex-protocol/utils';
 import {
+  Candlestick,
   IndexerEvent,
   IndexerEventWithTx,
   IndexerFoundationTakerGlobalRewardsForProduct,
@@ -23,6 +24,7 @@ import {
   IndexerLeaderboardParticipant,
   IndexerLeaderboardRegistration,
   IndexerMaker,
+  IndexerMarketSnapshot,
   IndexerMatchEventBalances,
   IndexerOrder,
   IndexerPerpBalance,
@@ -30,6 +32,7 @@ import {
   IndexerProductPayment,
   IndexerRewardsEpoch,
   IndexerServerBalance,
+  IndexerServerCandlestick,
   IndexerServerEvent,
   IndexerServerFoundationTakerRewardsWeek,
   IndexerServerFundingRate,
@@ -37,6 +40,7 @@ import {
   IndexerServerLeaderboardPosition,
   IndexerServerLeaderboardRegistration,
   IndexerServerMaker,
+  IndexerServerMarketSnapshot,
   IndexerServerMatchEventBalances,
   IndexerServerOrder,
   IndexerServerPerpPrices,
@@ -334,5 +338,59 @@ export function mapIndexerLeaderboardContest(
     requiredProductIds: contest.product_ids,
     active: contest.active,
     lastUpdated: toBigDecimal(contest.last_updated),
+  };
+}
+
+export function mapIndexerCandlesticks(
+  candlestick: IndexerServerCandlestick,
+): Candlestick {
+  return {
+    close: fromX18(candlestick.close_x18),
+    high: fromX18(candlestick.high_x18),
+    low: fromX18(candlestick.low_x18),
+    open: fromX18(candlestick.open_x18),
+    time: toBigDecimal(candlestick.timestamp),
+    volume: toBigDecimal(candlestick.volume),
+  };
+}
+
+export function mapIndexerMarketSnapshot(
+  snapshot: IndexerServerMarketSnapshot,
+): IndexerMarketSnapshot {
+  return {
+    timestamp: toBigDecimal(snapshot.timestamp),
+    cumulativeUsers: toBigDecimal(snapshot.cumulative_users),
+    dailyActiveUsers: toBigDecimal(snapshot.daily_active_users),
+    tvl: toBigDecimal(snapshot.tvl),
+    borrowRates: mapValues(snapshot.borrow_rates, fromX18),
+    cumulativeLiquidationAmounts: mapValues(
+      snapshot.cumulative_liquidation_amounts,
+      toBigDecimal,
+    ),
+    cumulativeMakerFees: mapValues(
+      snapshot.cumulative_maker_fees,
+      toBigDecimal,
+    ),
+    cumulativeSequencerFees: mapValues(
+      snapshot.cumulative_sequencer_fees,
+      toBigDecimal,
+    ),
+    cumulativeTakerFees: mapValues(
+      snapshot.cumulative_taker_fees,
+      toBigDecimal,
+    ),
+    cumulativeTrades: mapValues(snapshot.cumulative_trades, toBigDecimal),
+    cumulativeVolumes: mapValues(snapshot.cumulative_volumes, toBigDecimal),
+    depositRates: mapValues(snapshot.deposit_rates, fromX18),
+    fundingRates: mapValues(snapshot.funding_rates, fromX18),
+    openInterests: mapValues(snapshot.open_interests, fromX18),
+    totalBorrows: mapValues(snapshot.total_borrows, toBigDecimal),
+    totalDeposits: mapValues(snapshot.total_deposits, toBigDecimal),
+    cumulativeTradeSizes: mapValues(
+      snapshot.cumulative_trade_sizes,
+      toBigDecimal,
+    ),
+    cumulativeInflows: mapValues(snapshot.cumulative_inflows, toBigDecimal),
+    cumulativeOutflows: mapValues(snapshot.cumulative_outflows, toBigDecimal),
   };
 }

--- a/packages/indexer-client/src/types/clientTypes.ts
+++ b/packages/indexer-client/src/types/clientTypes.ts
@@ -253,7 +253,7 @@ export interface IndexerMarketSnapshot {
   cumulativeMakerFees: Record<number, BigDecimal>;
   cumulativeTrades: Record<number, BigDecimal>;
   cumulativeLiquidationAmounts: Record<number, BigDecimal>;
-  openInterests: Record<number, BigDecimal>;
+  openInterestsQuote: Record<number, BigDecimal>;
   totalDeposits: Record<number, BigDecimal>;
   totalBorrows: Record<number, BigDecimal>;
   fundingRates: Record<number, BigDecimal>;

--- a/packages/indexer-client/src/types/clientTypes.ts
+++ b/packages/indexer-client/src/types/clientTypes.ts
@@ -266,8 +266,13 @@ export interface IndexerMarketSnapshot {
 
 export type GetIndexerMarketSnapshotsResponse = IndexerMarketSnapshot[];
 
-export type GetIndexerEdgeMarketSnapshotsParams =
-  GetIndexerMarketSnapshotsParams;
+export interface GetIndexerEdgeMarketSnapshotsParams {
+  // Currently accepts all integers, in seconds
+  granularity: number;
+  // Seconds
+  maxTimeInclusive?: number;
+  limit: number;
+}
 
 // Map of chain id -> IndexerMarketSnapshot[]
 export type GetIndexerEdgeMarketSnapshotResponse = Record<

--- a/packages/indexer-client/src/types/clientTypes.ts
+++ b/packages/indexer-client/src/types/clientTypes.ts
@@ -195,6 +195,10 @@ export interface Candlestick {
 
 export type GetIndexerCandlesticksResponse = Candlestick[];
 
+export type GetIndexerEdgeCandlesticksResponse = GetIndexerCandlesticksResponse;
+
+export type GetIndexerEdgeCandlesticksParams = GetIndexerCandlesticksParams;
+
 /**
  * Product snapshots
  */
@@ -261,6 +265,15 @@ export interface IndexerMarketSnapshot {
 }
 
 export type GetIndexerMarketSnapshotsResponse = IndexerMarketSnapshot[];
+
+export type GetIndexerEdgeMarketSnapshotsParams =
+  GetIndexerMarketSnapshotsParams;
+
+// Map of chain id -> IndexerMarketSnapshot[]
+export type GetIndexerEdgeMarketSnapshotResponse = Record<
+  number,
+  IndexerMarketSnapshot[]
+>;
 
 /**
  * Events

--- a/packages/indexer-client/src/types/serverTypes.ts
+++ b/packages/indexer-client/src/types/serverTypes.ts
@@ -85,6 +85,9 @@ export interface IndexerServerCandlesticksParams {
   limit: number;
 }
 
+export type IndexerEdgeServerCandlesticksParams =
+  IndexerServerCandlesticksParams;
+
 export interface IndexerServerProductsParams {
   product_id: number;
   max_time?: number;
@@ -144,6 +147,9 @@ export interface IndexerServerMarketSnapshotsParams {
   // Defaults to all
   product_ids?: number[];
 }
+
+export type IndexerEdgeServerMarketSnapshotsParams =
+  IndexerServerMarketSnapshotsParams;
 
 export interface IndexerServerInterestFundingParams {
   subaccount: string;
@@ -227,6 +233,7 @@ export interface IndexerServerQueryRequestByType {
   blitz_points: IndexerServerBlitzPointsParams;
   blitz_points_leaderboard: IndexerServerBlitzPointsLeaderboardParams;
   candlesticks: IndexerServerCandlesticksParams;
+  edge_candlesticks: IndexerEdgeServerCandlesticksParams;
   events: IndexerServerEventsParams;
   funding_rate: IndexerServerFundingRateParams;
   funding_rates: IndexerServerFundingRatesParams;
@@ -235,6 +242,7 @@ export interface IndexerServerQueryRequestByType {
   linked_signer_rate_limit: IndexerServerLinkedSignerParams;
   maker_statistics: IndexerServerMakerStatisticsParams;
   market_snapshots: IndexerServerMarketSnapshotsParams;
+  edge_market_snapshots: IndexerEdgeServerMarketSnapshotsParams;
   matches: IndexerServerMatchEventsParams;
   oracle_price: IndexerServerOraclePricesParams;
   orders: IndexerServerOrdersParams;
@@ -328,6 +336,9 @@ export interface IndexerServerCandlesticksResponse {
   candlesticks: IndexerServerCandlestick[];
 }
 
+export type IndexerEdgeServerCandlesticksResponse =
+  IndexerServerCandlesticksResponse;
+
 export interface IndexerServerProductsResponse {
   products: IndexerServerProductSnapshot[];
   txs: IndexerServerTx[];
@@ -366,6 +377,10 @@ export interface IndexerServerLinkedSignerResponse {
 
 export interface IndexerServerMarketSnapshotsResponse {
   snapshots: IndexerServerMarketSnapshot[];
+}
+
+export interface IndexerEdgeServerMarketSnapshotsResponse {
+  snapshots: Record<number, IndexerServerMarketSnapshot[]>;
 }
 
 export interface IndexerServerInterestFundingResponse {
@@ -464,6 +479,7 @@ export interface IndexerServerQueryResponseByType {
   blitz_points: IndexerServerBlitzPointsResponse;
   blitz_points_leaderboard: IndexerServerBlitzPointsLeaderboardResponse;
   candlesticks: IndexerServerCandlesticksResponse;
+  edge_candlesticks: IndexerEdgeServerCandlesticksResponse;
   events: IndexerServerEventsResponse;
   funding_rate: IndexerServerFundingRateResponse;
   funding_rates: IndexerServerFundingRatesResponse;
@@ -472,6 +488,7 @@ export interface IndexerServerQueryResponseByType {
   linked_signer_rate_limit: IndexerServerLinkedSignerResponse;
   maker_statistics: IndexerServerMakerStatisticsResponse;
   market_snapshots: IndexerServerMarketSnapshotsResponse;
+  edge_market_snapshots: IndexerEdgeServerMarketSnapshotsResponse;
   matches: IndexerServerMatchEventsResponse;
   oracle_price: IndexerServerOraclePricesResponse;
   orders: IndexerServerOrdersResponse;

--- a/packages/indexer-client/src/types/serverTypes.ts
+++ b/packages/indexer-client/src/types/serverTypes.ts
@@ -148,8 +148,9 @@ export interface IndexerServerMarketSnapshotsParams {
   product_ids?: number[];
 }
 
-export type IndexerEdgeServerMarketSnapshotsParams =
-  IndexerServerMarketSnapshotsParams;
+export interface IndexerEdgeServerMarketSnapshotsParams {
+  interval: IndexerServerMarketSnapshotInterval;
+}
 
 export interface IndexerServerInterestFundingParams {
   subaccount: string;


### PR DESCRIPTION
This PR adds market query fns for `edge_candlesticks` and `edge_market_snapshots`, intended to be used in the FE to show cross-chain aggregated market data such as vol, trades, and OI.

First time adding queries to the SDK and tried to just follow existing patterns, but very well could be missing some things.