### PR TITLE
Add subaccount and base tx fields for indexer query responses

### DIFF
--- a/packages/indexer-client/src/IndexerBaseClient.ts
+++ b/packages/indexer-client/src/IndexerBaseClient.ts
@@ -17,6 +17,7 @@ import {
   toBigDecimal,
 } from '@vertex-protocol/utils';
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
+import { BigNumberish, Signer } from 'ethers';
 import {
   mapIndexerCandlesticks,
   mapIndexerEvent,
@@ -120,7 +121,6 @@ import {
   UpdateIndexerLeaderboardRegistrationParams,
   UpdateIndexerLeaderboardRegistrationResponse,
 } from './types';
-import { BigNumberish, Signer } from 'ethers';
 
 export interface IndexerClientOpts {
   // Server URLs
@@ -583,6 +583,7 @@ export class IndexerBaseClient {
         preBalances: mapIndexerMatchEventBalances(matchEvent.pre_balance),
         postBalances: mapIndexerMatchEventBalances(matchEvent.post_balance),
         tx,
+        ...subaccountFromHex(matchEvent.order.sender),
       };
     });
   }
@@ -1025,14 +1026,6 @@ export class IndexerBaseClient {
     return response.data;
   }
 
-  private checkResponseStatus(response: AxiosResponse) {
-    if (response.status !== 200 || !response.data) {
-      throw Error(
-        `Unexpected response from server: ${response.status} ${response.statusText}`,
-      );
-    }
-  }
-
   protected async sign<T extends SignableRequestType>(
     requestType: T,
     verifyingContract: string,
@@ -1050,5 +1043,13 @@ export class IndexerBaseClient {
       signer,
       verifyingContract,
     });
+  }
+
+  private checkResponseStatus(response: AxiosResponse) {
+    if (response.status !== 200 || !response.data) {
+      throw Error(
+        `Unexpected response from server: ${response.status} ${response.statusText}`,
+      );
+    }
   }
 }

--- a/packages/indexer-client/src/IndexerClient.ts
+++ b/packages/indexer-client/src/IndexerClient.ts
@@ -1,6 +1,7 @@
 import {
   ProductEngineType,
   QUOTE_PRODUCT_ID,
+  subaccountFromHex,
 } from '@vertex-protocol/contracts';
 import { toBigDecimal } from '@vertex-protocol/utils';
 
@@ -106,6 +107,8 @@ export class IndexerClient extends IndexerBaseClient {
           quoteSnapshot: undefined,
           timestamp: event.timestamp,
           submissionIndex: event.submissionIndex,
+          tx: event.tx,
+          ...subaccountFromHex(event.subaccount),
         };
         eventsBySubmissionIdx.set(event.submissionIndex, newEvent);
 
@@ -190,6 +193,8 @@ export class IndexerClient extends IndexerBaseClient {
           event.state.preBalance.amount,
         ),
         newAmount: event.state.postBalance.amount,
+        tx: event.tx,
+        ...subaccountFromHex(event.subaccount),
       };
     });
 
@@ -270,6 +275,8 @@ export class IndexerClient extends IndexerBaseClient {
           quoteDelta: event.state.preBalance.vQuoteBalance.minus(
             event.state.postBalance.vQuoteBalance,
           ),
+          tx: event.tx,
+          ...subaccountFromHex(event.subaccount),
         };
       })
       .filter((event): event is IndexerSettlementEvent => !!event);

--- a/packages/indexer-client/src/types/VertexTx.ts
+++ b/packages/indexer-client/src/types/VertexTx.ts
@@ -35,9 +35,28 @@ export interface VertexWithdrawCollateralTx {
   };
 }
 
+export interface VertexDepositCollateralTx {
+  deposit_collateral: {
+    sender: string;
+    product_id: number;
+    amount: string;
+  };
+}
+
+export interface VertexTransferQuoteTx {
+  transfer_quote: {
+    sender: string;
+    recipient: string;
+    amount: string;
+    nonce: number;
+  };
+}
+
 export type VertexTx =
   | VertexMatchOrdersTx
   | VertexMatchOrdersRfqTx
   | VertexLiquidateSubaccountTx
+  | VertexDepositCollateralTx
+  | VertexTransferQuoteTx
   | VertexWithdrawCollateralTx
   | any;

--- a/packages/indexer-client/src/types/clientTypes.ts
+++ b/packages/indexer-client/src/types/clientTypes.ts
@@ -10,6 +10,7 @@ import {
   Subaccount,
 } from '@vertex-protocol/contracts';
 import { BigDecimal } from '@vertex-protocol/utils';
+import { BigNumberish } from 'ethers';
 import { CandlestickPeriod } from './CandlestickPeriod';
 import { IndexerEventType } from './IndexerEventType';
 import { IndexerLeaderboardRankType } from './IndexerLeaderboardType';
@@ -21,7 +22,6 @@ import {
   IndexerServerListSubaccountsParams,
 } from './serverTypes';
 import { VertexTx, VertexWithdrawCollateralTx } from './VertexTx';
-import { BigNumberish } from 'ethers';
 
 /**
  * Base types
@@ -382,7 +382,7 @@ export interface IndexerMatchEventBalances {
   quote?: IndexerSpotBalance;
 }
 
-export interface IndexerMatchEvent {
+export interface IndexerMatchEvent extends Subaccount {
   productId: number;
   digest: string;
   order: EIP712OrderValues;

--- a/packages/indexer-client/src/types/paginatedEventsTypes.ts
+++ b/packages/indexer-client/src/types/paginatedEventsTypes.ts
@@ -17,6 +17,7 @@ import {
   IndexerOrder,
 } from './clientTypes';
 import { CollateralEventType } from './collateralEventType';
+import { VertexTx } from './VertexTx';
 
 export interface IndexerPaginationParams {
   limit: number;
@@ -40,9 +41,10 @@ type BaseSubaccountPaginationParams = Subaccount &
     maxTimestampInclusive?: number;
   };
 
-export interface BaseIndexerPaginatedEvent {
+export interface BaseIndexerPaginatedEvent extends Subaccount {
   timestamp: BigDecimal;
   submissionIndex: string;
+  tx: VertexTx;
 }
 
 export interface PaginatedIndexerEventsResponse<


### PR DESCRIPTION
These essentially expose the fields necessary for us to tell what `subaccountName` transactions are associated with, allowing us to differentiate between iso/cross actions