### PR TITLE
Explicitly specify 0dp in BigDecimal.toFixed()

### DIFF
--- a/packages/client/src/apis/rewards/RewardsExecuteAPI.ts
+++ b/packages/client/src/apis/rewards/RewardsExecuteAPI.ts
@@ -23,7 +23,7 @@ export class RewardsExecuteAPI extends BaseVertexAPI {
 
     return this.context.contracts.vrtxAirdrop.claimToLBA(
       params.amount,
-      totalAmount.toFixed(),
+      totalAmount.toFixed(0),
       proof,
     );
   }
@@ -172,7 +172,7 @@ export class RewardsExecuteAPI extends BaseVertexAPI {
       if (item.totalAmount.gt(0) && claimed[idx] === 0n) {
         proofsToClaim.push({
           proof: item.proof,
-          totalAmount: item.totalAmount.toFixed(),
+          totalAmount: item.totalAmount.toFixed(0),
           week: idx,
         });
       }
@@ -211,9 +211,9 @@ export class RewardsExecuteAPI extends BaseVertexAPI {
         amountsClaimed.at(params.epoch)?.toString() ?? 0,
       );
 
-      return availableAmount.toFixed();
+      return availableAmount.toFixed(0);
     })();
 
-    return [params.epoch, amountToClaim, totalAmount.toFixed(), proof];
+    return [params.epoch, amountToClaim, totalAmount.toFixed(0), proof];
   }
 }

--- a/packages/engine-client/src/EngineQueryClient.ts
+++ b/packages/engine-client/src/EngineQueryClient.ts
@@ -150,7 +150,7 @@ export class EngineQueryClient extends EngineBaseClient {
                 burn_lp: {
                   product_id: tx.tx.productId,
                   subaccount,
-                  amount_lp: tx.tx.amountLp.toFixed(),
+                  amount_lp: tx.tx.amountLp.toFixed(0),
                 },
               };
             case 'apply_delta':
@@ -158,8 +158,8 @@ export class EngineQueryClient extends EngineBaseClient {
                 apply_delta: {
                   product_id: tx.tx.productId,
                   subaccount,
-                  amount_delta: tx.tx.amountDelta.toFixed(),
-                  v_quote_delta: tx.tx.vQuoteDelta.toFixed(),
+                  amount_delta: tx.tx.amountDelta.toFixed(0),
+                  v_quote_delta: tx.tx.vQuoteDelta.toFixed(0),
                 },
               };
             case 'mint_lp':
@@ -167,9 +167,9 @@ export class EngineQueryClient extends EngineBaseClient {
                 mint_lp: {
                   product_id: tx.tx.productId,
                   subaccount,
-                  amount_base: tx.tx.amountBase.toFixed(),
-                  quote_amount_low: tx.tx.amountQuoteLow.toFixed(),
-                  quote_amount_high: tx.tx.amountQuoteHigh.toFixed(),
+                  amount_base: tx.tx.amountBase.toFixed(0),
+                  quote_amount_low: tx.tx.amountQuoteLow.toFixed(0),
+                  quote_amount_high: tx.tx.amountQuoteHigh.toFixed(0),
                 },
               };
           }

--- a/packages/engine-client/src/utils/queryDataMappers.ts
+++ b/packages/engine-client/src/utils/queryDataMappers.ts
@@ -56,10 +56,10 @@ export function mapEngineServerOrder(
     // Standardizes from hex
     // toFixed is required as toString gives values with `e`
     orderParams: {
-      amount: toBigDecimal(order.amount).toFixed(),
-      expiration: toBigDecimal(order.expiration).toFixed(),
+      amount: toBigDecimal(order.amount).toFixed(0),
+      expiration: toBigDecimal(order.expiration).toFixed(0),
       nonce: order.nonce,
-      price: fromX18(order.price_x18).toFixed(),
+      price: fromX18(order.price_x18).toFixed(0),
       subaccountOwner: subaccount.subaccountOwner,
       subaccountName: subaccount.subaccountName,
     },

--- a/packages/indexer-client/src/IndexerBaseClient.ts
+++ b/packages/indexer-client/src/IndexerBaseClient.ts
@@ -979,7 +979,8 @@ export class IndexerBaseClient {
   ): Promise<UpdateIndexerLeaderboardRegistrationResponse> {
     const signatureParams: EIP712LeaderboardAuthenticationParams = {
       // Default to 90 seconds from now if no recvTime is provided
-      expiration: params.recvTime?.toFixed() ?? getDefaultRecvTime().toFixed(),
+      expiration:
+        params.recvTime?.toFixed(0) ?? getDefaultRecvTime().toFixed(0),
       subaccountName: params.subaccountName,
       subaccountOwner: params.subaccountOwner,
     };

--- a/packages/indexer-client/src/IndexerClient.ts
+++ b/packages/indexer-client/src/IndexerClient.ts
@@ -454,7 +454,7 @@ export class IndexerClient extends IndexerBaseClient {
       meta: {
         hasMore: baseResponse.epochs.length > requestedLimit,
         // Next cursor is the epoch number of the (requestedLimit+1)th item
-        nextCursor: baseResponse.epochs[requestedLimit]?.epoch.toFixed(),
+        nextCursor: baseResponse.epochs[requestedLimit]?.epoch.toFixed(0),
       },
     };
   }
@@ -484,7 +484,7 @@ export class IndexerClient extends IndexerBaseClient {
       meta: {
         hasMore: baseResponse.positions.length > requestedLimit,
         // Next cursor is the rank number of the (requestedLimit+1)th item
-        nextCursor: baseResponse.positions[requestedLimit]?.rank.toFixed(),
+        nextCursor: baseResponse.positions[requestedLimit]?.rank.toFixed(0),
       },
     };
   }
@@ -513,7 +513,7 @@ export class IndexerClient extends IndexerBaseClient {
       meta: {
         hasMore: baseResponse.positions.length > requestedLimit,
         // Next cursor is the rank number of the (requestedLimit+1)th item
-        nextCursor: baseResponse.positions[requestedLimit]?.rank.toFixed(),
+        nextCursor: baseResponse.positions[requestedLimit]?.rank.toFixed(0),
       },
     };
   }
@@ -546,8 +546,8 @@ export class IndexerClient extends IndexerBaseClient {
         // Next cursor is the rank number of the (requestedLimit+1)th item
         nextCursor:
           params.rankType == 'pnl'
-            ? baseResponse.participants[requestedLimit]?.pnlRank.toFixed()
-            : baseResponse.participants[requestedLimit]?.roiRank.toFixed(),
+            ? baseResponse.participants[requestedLimit]?.pnlRank.toFixed(0)
+            : baseResponse.participants[requestedLimit]?.roiRank.toFixed(0),
       },
     };
   }

--- a/packages/trigger-client/src/TriggerClient.ts
+++ b/packages/trigger-client/src/TriggerClient.ts
@@ -153,7 +153,7 @@ export class TriggerClient {
   ): Promise<TriggerListOrdersResponse> {
     const signatureParams: EIP712ListTriggerOrdersParams = {
       // Default to 90 seconds from now if no recvTime is provided
-      recvTime: params.recvTime?.toFixed() ?? getDefaultRecvTime().toFixed(),
+      recvTime: params.recvTime?.toFixed(0) ?? getDefaultRecvTime().toFixed(0),
       subaccountName: params.subaccountName,
       subaccountOwner: params.subaccountOwner,
     };

--- a/packages/utils/src/math/fixedPoint.ts
+++ b/packages/utils/src/math/fixedPoint.ts
@@ -44,7 +44,7 @@ export function toFixedPoint(val: BigDecimalish, decimals = 18): bigint {
   // toFixed is required here to avoid exponential notation
   const valToParse = bigDecimalVal
     .times(toBigDecimal(10).pow(decimals))
-    .toFixed();
+    .toFixed(0);
 
   return BigInt(valToParse);
 }


### PR DESCRIPTION
This was an oversight on my part. We use `toFixed()` to convert a `BigDecimal` to a `string` with 0 decimal places. Omitting the `0` param in `Number.toFixed()` defaults to 0dp, but this isn't the case for `BigDecimal` (https://mikemcl.github.io/bignumber.js/#toFix):

<img width="701" alt="image" src="https://github.com/user-attachments/assets/6be3f6f8-efe6-4284-881c-1100ce22ccab" />

