### PR TITLE
housekeeping: update gitignore to align with monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 
 .DS_store
 .idea/
+.vscode
+.cursor*
+.windsurf*
+.codeium*
 
 *.tsbuildinfo
 dist/
@@ -46,3 +50,6 @@ jspm_packages
 # Optional REPL history
 .node_repl_history
 .next
+
+# eslint
+.eslintcache


### PR DESCRIPTION
This PR updates gitignore to align with monorepo (ignore more IDEs and eslintcache)