### PR TITLE
fix: "nonce too low" e2e errors due to concurrency

### DIFF
--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -12,11 +12,11 @@
   "repository": "https://github.com/vertex-protocol/vertex-typescript-sdk",
   "scripts": {
     "account-setup": "tsx ./src/utils/accountSetup.ts",
-    "e2e": "tsx --test",
-    "e2e:client": "tsx --test ./src/client/*.test.ts",
-    "e2e:engine": "tsx --test ./src/engine-client/*.test.ts",
-    "e2e:indexer": "tsx --test ./src/indexer-client/*.test.ts",
-    "e2e:trigger": "tsx --test ./src/trigger-client/*.test.ts",
+    "e2e": "tsx --test --test-concurrency=1",
+    "e2e:client": "tsx --test --test-concurrency=1 ./src/client/*.test.ts",
+    "e2e:engine": "tsx --test --test-concurrency=1 ./src/engine-client/*.test.ts",
+    "e2e:indexer": "tsx --test --test-concurrency=1 ./src/indexer-client/*.test.ts",
+    "e2e:trigger": "tsx --test --test-concurrency=1 ./src/trigger-client/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
Context: https://www.notion.so/vertexprotocol/Eng-Task-Planning-1bafec14f62e4c1bac82e63aaa8dc68d?p=1fd4976028f0802ba03bdf09966a0a2e&pm=s

This PR fixes "nonce too low" errors when running `e2e`.

Turns out `getTxNonceIfNeeded` actually used the correct address every time (as in, `walletClient.account.address` is always equal to `subaccountOwner` in our tests).
Anyway, "nonce too low" errors also happened with transactions calling contract directly (so not going through EngineExecuteBuilder's `getTxNonceIfNeeded`).

The root cause for the issue was that node test runner uses concurrency by default for running tests, which is something we can't do with EVM due to nonces, if we're using the same account for all tests.
