### PR TITLE
fix funding rate pagination

### DIFF
--- a/packages/indexer-client/src/IndexerBaseClient.ts
+++ b/packages/indexer-client/src/IndexerBaseClient.ts
@@ -615,7 +615,8 @@ export class IndexerBaseClient {
    * Retrieves historical funding & interest payments.
    * NOTE: `limit` is an upperbound. If a user changes position size such that his position is 0 during each funding/interest tick,
    *        then the indexer will return fewer than `limit` results per page. However, all events are actually present,
-   *        we'll just need to keep paginating until the next cursor is null.
+   *        We typically determine that there are no pages if `nextCursor` is null, but there can still be an edge case
+   *        where `nextCursor` is defined if a query comes back with nothing. This is due to how the data is organized.
    *
    * @param params
    */

--- a/packages/indexer-client/src/IndexerClient.ts
+++ b/packages/indexer-client/src/IndexerClient.ts
@@ -480,7 +480,11 @@ export class IndexerClient extends IndexerBaseClient {
   /**
    * Get all interest funding payments for a given subaccount with the standard pagination response
    * This is a simple wrapper over the underlying `getInterestFundingPayments` function. Very little
-   * additional processing is needed because the endpoint is well structured for pagination
+   * additional processing is needed because the endpoint is well structured for pagination.
+   *
+   * We are omitting `nextCursor` & `hasMore`. We typically determine that there are no pages if `nextCursor` is null,
+   * but there can still be an edge case where `nextCursor` is defined if a query comes back with nothing
+   * This is due to how the data is organized.
    *
    * @param params
    */


### PR DESCRIPTION
This pull request updates the `IndexerBaseClient` and `IndexerClient` classes in the `packages/indexer-client` module to refine the pagination logic for retrieving historical funding and interest payments. The changes ensure more accurate handling of the `limit` parameter and improve the returned data structure.

### Pagination logic improvements:

* [`packages/indexer-client/src/IndexerBaseClient.ts`](diffhunk://#diff-1a59e593d5688c43202632d4464fd753b47ef4b4d3abf2e0593265a8877f146fL617-R648): Updated the `getInterestFundingPayments` method to use `limit + 1` for querying data and adjusted the logic to calculate the `nextCursor` based on the `limit` + 1th item. The returned funding and interest payments are now sliced to match the requested limit, ensuring proper pagination.