### PR TITLE
integrate claim multiple epoch rewards

### DIFF
--- a/packages/client/src/apis/rewards/RewardsExecuteAPI.ts
+++ b/packages/client/src/apis/rewards/RewardsExecuteAPI.ts
@@ -2,8 +2,6 @@ import { toBigInt } from '@vertex-protocol/utils';
 import { Hex } from 'viem';
 import { BaseRewardsAPI } from './BaseRewardsAPI';
 import {
-  ClaimLiquidTokensParams,
-  ClaimLiquidTokensSatelliteParams,
   SatelliteCcipParams,
   StakeSatelliteParams,
   VrtxTokenAmountParams,
@@ -28,27 +26,33 @@ export class RewardsExecuteAPI extends BaseRewardsAPI {
   /**
    * Claim earned VRTX tokens
    */
-  async claimLiquidTokens(params: ClaimLiquidTokensParams) {
-    return this.context.contracts.vrtxAirdrop.write.claim(
-      await this.getClaimLiquidTokensContractParams(params),
-    );
+  async claimAllLiquidTokens() {
+    const proofsToClaim = await this.getClaimAllLiquidTokensContractParams();
+
+    return this.context.contracts.vrtxAirdrop.write.claimMultiple([
+      proofsToClaim,
+    ]);
   }
 
   /**
    * Claim earned VRTX tokens and stake them
    */
-  async claimAndStakeLiquidTokens(params: ClaimLiquidTokensParams) {
-    return this.context.contracts.vrtxAirdrop.write.claimAndStake(
-      await this.getClaimLiquidTokensContractParams(params),
-    );
+  async claimAndStakeAllLiquidTokens() {
+    const proofsToClaim = await this.getClaimAllLiquidTokensContractParams();
+
+    return this.context.contracts.vrtxAirdrop.write.claimMultipleAndStake([
+      proofsToClaim,
+    ]);
   }
 
   /**
    * Claim earned VRTX tokens on non-canonical chains
    */
-  async claimLiquidTokensSatellite(params: ClaimLiquidTokensSatelliteParams) {
-    return this.context.contracts.vrtxStakingV2Satellite.write.claim(
-      await this.getClaimLiquidTokensContractParams(params),
+  async claimAllLiquidTokensSatellite(params: SatelliteCcipParams) {
+    const proofsToClaim = await this.getClaimAllLiquidTokensContractParams();
+
+    return this.context.contracts.vrtxStakingV2Satellite.write.claimMultiple(
+      [proofsToClaim],
       { value: toBigInt(params.ccipFee) },
     );
   }
@@ -56,11 +60,11 @@ export class RewardsExecuteAPI extends BaseRewardsAPI {
   /**
    * Claim trading rewards and stake the claimed VRTX on non-canonical chains
    */
-  async claimAndStakeLiquidTokensSatellite(
-    params: ClaimLiquidTokensSatelliteParams,
-  ) {
-    return this.context.contracts.vrtxStakingV2Satellite.write.claimAndStake(
-      await this.getClaimLiquidTokensContractParams(params),
+  async claimAndStakeAllLiquidTokensSatellite(params: SatelliteCcipParams) {
+    const proofsToClaim = await this.getClaimAllLiquidTokensContractParams();
+
+    return this.context.contracts.vrtxStakingV2Satellite.write.claimMultipleAndStake(
+      [proofsToClaim],
       { value: toBigInt(params.ccipFee) },
     );
   }

--- a/packages/client/src/apis/rewards/RewardsQueryAPI.ts
+++ b/packages/client/src/apis/rewards/RewardsQueryAPI.ts
@@ -9,11 +9,7 @@ import {
   zeroHash,
 } from 'viem';
 import { BaseRewardsAPI } from './BaseRewardsAPI';
-import {
-  ClaimLiquidTokensParams,
-  SatelliteTransactionType,
-  VrtxTokenAmountParams,
-} from './types';
+import { SatelliteTransactionType, VrtxTokenAmountParams } from './types';
 
 export class RewardsQueryAPI extends BaseRewardsAPI {
   /**
@@ -68,10 +64,12 @@ export class RewardsQueryAPI extends BaseRewardsAPI {
    * @param params
    * @returns
    */
-  async getClaimLiquidTokensCcipFee(params: ClaimLiquidTokensParams) {
+  async getClaimLiquidTokensCcipFee() {
+    const proofs = await this.getClaimAllLiquidTokensContractParams();
+
     const encodedAbiParams = encodeAbiParameters(
       this.getFunctionAbiInputs('claim'),
-      await this.getClaimLiquidTokensContractParams(params),
+      [proofs],
     );
 
     return this.getEstimatedCcipFee(
@@ -85,10 +83,12 @@ export class RewardsQueryAPI extends BaseRewardsAPI {
    * @param params
    * @returns
    */
-  async getClaimAndStakeLiquidTokensCcipFee(params: ClaimLiquidTokensParams) {
+  async getClaimAndStakeLiquidTokensCcipFee() {
+    const proofs = await this.getClaimAllLiquidTokensContractParams();
+
     const encodedAbiParams = encodeAbiParameters(
       this.getFunctionAbiInputs('claimAndStake'),
-      await this.getClaimLiquidTokensContractParams(params),
+      [proofs],
     );
 
     return this.getEstimatedCcipFee(

--- a/packages/client/src/apis/rewards/types.ts
+++ b/packages/client/src/apis/rewards/types.ts
@@ -1,4 +1,6 @@
+import { VertexAbis } from '@vertex-protocol/contracts';
 import { BigDecimalish } from '@vertex-protocol/utils';
+import { WriteContractParameters } from 'viem';
 
 export interface VrtxTokenAmountParams {
   amount: BigDecimalish;
@@ -10,25 +12,18 @@ export interface SatelliteCcipParams {
 
 export type StakeSatelliteParams = VrtxTokenAmountParams & SatelliteCcipParams;
 
-// Either specify the amount, or attempt to claim all available tokens
-type AmountOrAllParams =
-  | VrtxTokenAmountParams
-  | {
-      claimAll: true;
-    };
-
-export type ClaimLiquidTokensParams = AmountOrAllParams & {
-  epoch: number;
-};
-
-export type ClaimLiquidTokensSatelliteParams = ClaimLiquidTokensParams &
-  SatelliteCcipParams;
+export type RewardsLiquidTokensProof = WriteContractParameters<
+  VertexAbis['vrtxAirdrop'],
+  'claimMultiple'
+>['args'][number][number];
 
 export enum SatelliteTransactionType {
   STAKE_AS = 0,
   WITHDRAW = 1,
   WITHDRAW_SLOW = 2,
   CLAIM_WITHDRAW = 3,
-  CLAIM = 4,
-  CLAIM_AND_STAKE = 5,
+  CLAIM_MULTIPLE = 4,
+  CLAIM = 5,
+  CLAIM_MULTIPLE_AND_STAKE = 6,
+  CLAIM_AND_STAKE = 7,
 }

--- a/packages/contracts/src/common/abis/Airdrop.ts
+++ b/packages/contracts/src/common/abis/Airdrop.ts
@@ -83,6 +83,109 @@ export const AIRDROP_ABI = [
   {
     inputs: [
       {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        internalType: 'uint32',
+        name: 'epoch',
+        type: 'uint32',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'totalAmount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes32[]',
+        name: 'proof',
+        type: 'bytes32[]',
+      },
+    ],
+    name: 'claimAs',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'uint32',
+            name: 'epoch',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint256',
+            name: 'amount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'totalAmount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'bytes32[]',
+            name: 'proof',
+            type: 'bytes32[]',
+          },
+        ],
+        internalType: 'struct IAirdrop.ClaimProof[]',
+        name: 'claimProofs',
+        type: 'tuple[]',
+      },
+    ],
+    name: 'claimMultiple',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'uint32',
+            name: 'epoch',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint256',
+            name: 'amount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'totalAmount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'bytes32[]',
+            name: 'proof',
+            type: 'bytes32[]',
+          },
+        ],
+        internalType: 'struct IAirdrop.ClaimProof[]',
+        name: 'claimProofs',
+        type: 'tuple[]',
+      },
+    ],
+    name: 'claimMultipleAndStake',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
         internalType: 'uint256',
         name: 'amount',
         type: 'uint256',

--- a/packages/contracts/src/common/abis/StakingV2Satellite.ts
+++ b/packages/contracts/src/common/abis/StakingV2Satellite.ts
@@ -68,6 +68,88 @@ export const STAKING_V2_SATELLITE_ABI = [
     type: 'function',
   },
   {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'uint32',
+            name: 'epoch',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint256',
+            name: 'amount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'totalAmount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'bytes32[]',
+            name: 'proof',
+            type: 'bytes32[]',
+          },
+        ],
+        internalType: 'struct IAirdrop.ClaimProof[]',
+        name: 'claimProofs',
+        type: 'tuple[]',
+      },
+    ],
+    name: 'claimMultiple',
+    outputs: [
+      {
+        internalType: 'bytes32[]',
+        name: 'messageIds',
+        type: 'bytes32[]',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'uint32',
+            name: 'epoch',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint256',
+            name: 'amount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'totalAmount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'bytes32[]',
+            name: 'proof',
+            type: 'bytes32[]',
+          },
+        ],
+        internalType: 'struct IAirdrop.ClaimProof[]',
+        name: 'claimProofs',
+        type: 'tuple[]',
+      },
+    ],
+    name: 'claimMultipleAndStake',
+    outputs: [
+      {
+        internalType: 'bytes32[]',
+        name: 'messageIds',
+        type: 'bytes32[]',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
     inputs: [],
     name: 'claimWithdraw',
     outputs: [


### PR DESCRIPTION
### Refactoring and simplification of rewards APIs:

* [`packages/client/src/apis/rewards/BaseRewardsAPI.ts`](diffhunk://#diff-97fd0a67532196b256704f9daf1b2a91e3dc01953e4af5fbd83db302d7d1164cL1-R46): Refactored `getClaimLiquidTokensContractParams` to remove dependency on `ClaimLiquidTokensParams` and `ClaimLiquidTokensSatelliteParams`. The method now directly retrieves proofs and calculates amounts to claim for all epochs, enabling batch operations.
* [`packages/client/src/apis/rewards/RewardsExecuteAPI.ts`](diffhunk://#diff-f1317adf0779d4e8916bac5a0e2b8d7a4a837ec32756cb0a803431299afaf938L31-R65): Updated methods like `claimLiquidTokens` and `claimAndStakeLiquidTokens` to use batch operations (`claimMultiple` and `claimMultipleAndStake`) instead of single claims. Removed dependency on `ClaimLiquidTokensParams`.
* [`packages/client/src/apis/rewards/RewardsQueryAPI.ts`](diffhunk://#diff-16459fd581627909fd5774b3d92eae003af2a19f5074773231564c02f6e3eddeL71-R72): Modified methods to use batch proofs (`getClaimLiquidTokensCcipFee` and `getClaimAndStakeLiquidTokensCcipFee`), removing the need for individual claim parameters. [[1]](diffhunk://#diff-16459fd581627909fd5774b3d92eae003af2a19f5074773231564c02f6e3eddeL71-R72) [[2]](diffhunk://#diff-16459fd581627909fd5774b3d92eae003af2a19f5074773231564c02f6e3eddeL88-R91)

### Introduction of new types and contract methods:

* [`packages/client/src/apis/rewards/types.ts`](diffhunk://#diff-3c5fd80dbba36c19ce48bf000357b6e7c40e11904349110f27db09adabfc3fbfL13-R29): Added `RewardsLiquidTokensProof` type to represent proofs for batch claims. Removed `ClaimLiquidTokensParams` and `ClaimLiquidTokensSatelliteParams` types, simplifying the API.
* [`packages/contracts/src/common/abis/Airdrop.ts`](diffhunk://#diff-d1ba078c647c6b21acf92f3ddb52f6e55b29fa9f6c02431211e27ddc12430e4bR83-R185): Added new contract methods (`claimMultiple`, `claimMultipleAndStake`) to support batch operations for claiming and staking tokens.