### PR TITLE
docs(e2e): fix setup command

### DIFF
--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -6,7 +6,7 @@ Before running any tests, make sure to configure your environment and set up the
 
 1. Copy `.env.example` into `.env` and fill out any appropriate values
 
-2. Run the `bun account-setup` to mint and deposit tokens for the test account
+2. Run `bun fund` to mint and deposit tokens for the test account. From the repository root, run `bun --cwd apps/e2e fund`.
 
 ## E2E Tests
 


### PR DESCRIPTION
## Summary

Fixes the E2E setup instructions to use the existing `fund` script instead of the stale `account-setup` command.

Also mentions the equivalent command for running it from the repository root.

## Verification

- `rg -n "account-setup|bun fund|bun --cwd apps/e2e fund" apps/e2e/README.md`
- `rg -n '"fund"|"cleanup"|"account-setup"' apps/e2e/package.json`