### PR TITLE
add indexer linked signer

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -31,6 +31,7 @@ export class NadoClient {
     this.context.linkedSignerWalletClient =
       linkedSignerWalletClient ?? undefined;
     this.context.engineClient.setLinkedSigner(linkedSignerWalletClient);
+    this.context.indexerClient.setLinkedSigner(linkedSignerWalletClient);
     this.context.triggerClient.setLinkedSigner(linkedSignerWalletClient);
   }
 

--- a/packages/client/src/context.ts
+++ b/packages/client/src/context.ts
@@ -135,6 +135,7 @@ export function createClientContext(
     indexerClient: new IndexerClient({
       url: indexerEndpoint,
       walletClient,
+      linkedSignerWalletClient,
     }),
     triggerClient: new TriggerClient({
       url: triggerEndpoint,

--- a/packages/indexer-client/src/IndexerBaseClient.ts
+++ b/packages/indexer-client/src/IndexerBaseClient.ts
@@ -134,6 +134,8 @@ export interface IndexerClientOpts {
   v2Url?: string;
   // Wallet Client for EIP712 signing
   walletClient?: WalletClientWithAccount;
+  // Linked signer registered through the engine, if provided, execute requests will use this signer
+  linkedSignerWalletClient?: WalletClientWithAccount;
 }
 
 type IndexerQueryRequestBody = Partial<IndexerServerQueryRequestByType>;
@@ -154,6 +156,17 @@ export class IndexerBaseClient {
       validateStatus: () => true,
     });
     this.v2Url = opts.v2Url ? opts.v2Url : opts.url.replace('v1', 'v2');
+  }
+
+  /**
+   * Sets the linked signer for execute requests
+   *
+   * @param linkedSignerWalletClient The linkedSigner to use for all signatures. Set to null to revert to the chain signer
+   */
+  public setLinkedSigner(
+    linkedSignerWalletClient: WalletClientWithAccount | null,
+  ) {
+    this.opts.linkedSignerWalletClient = linkedSignerWalletClient ?? undefined;
   }
 
   /**
@@ -1051,7 +1064,8 @@ export class IndexerBaseClient {
     chainId: number,
     params: SignableRequestTypeToParams[T],
   ) {
-    const walletClient = this.opts.walletClient;
+    const walletClient =
+      this.opts.linkedSignerWalletClient ?? this.opts.walletClient;
 
     if (!walletClient) {
       throw new WalletNotProvidedError();


### PR DESCRIPTION
This pull request enhances support for using a linked signer wallet client across the codebase, particularly within the `IndexerClient` and related client context setup. The changes ensure that if a linked signer is provided (typically registered through the engine), it will be used for execute requests, otherwise the default chain signer is used. The most important changes are grouped below:

**Linked Signer Propagation and Usage:**

* Added `linkedSignerWalletClient` to the `IndexerClient` options and ensured it is passed during client context creation in `createClientContext`. [[1]](diffhunk://#diff-545914ddb02d3ba335284b78927d49d28e5bbc6c2b7b62723a91c3c716e41bd9R138) [[2]](diffhunk://#diff-1a59e593d5688c43202632d4464fd753b47ef4b4d3abf2e0593265a8877f146fR137-R138)
* Updated `IndexerBaseClient` to use the `linkedSignerWalletClient` for execute requests if available, falling back to the default wallet client otherwise.
* Implemented a `setLinkedSigner` method in `IndexerBaseClient` that allows dynamically updating the linked signer used for signatures.
* Ensured that when a linked signer is set in the main client (`NadoClient`), it is also propagated to the `IndexerClient`, keeping signer state consistent across all subclients.