### PR TITLE
add country code query

### DIFF
--- a/apps/e2e/src/client/query.test.ts
+++ b/apps/e2e/src/client/query.test.ts
@@ -75,6 +75,21 @@ void describe('[client]: queries', { timeout: TEST_TIMEOUTS.DEFAULT }, () => {
     assertDefined(time, 'engineTime');
   });
 
+  void test('getCountryCode returns ISO country code or null', async () => {
+    const country = await nadoClient.context.engineClient.getCountryCode();
+
+    debugPrint('Engine country code', country);
+
+    if (country !== null) {
+      assert.equal(typeof country, 'string', 'country should be a string');
+      assert.match(
+        country,
+        /^[A-Z]{2}$/,
+        'country should be a 2-letter ISO 3166-1 alpha-2 code',
+      );
+    }
+  });
+
   void test('getAllMarkets returns product definitions', async () => {
     const allMarkets = await nadoClient.market.getAllMarkets();
 

--- a/packages/engine-client/src/EngineWebClient.ts
+++ b/packages/engine-client/src/EngineWebClient.ts
@@ -1,9 +1,12 @@
 import { EngineBaseClient } from './EngineBaseClient';
 import {
   EngineServerIpBlockResponse,
+  GetEngineCountryCodeResponse,
   GetEngineIpBlockStatusResponse,
   GetEngineTimeResponse,
 } from './types';
+
+const COUNTRY_HEADER = 'x-nado-country';
 
 /**
  * Queries that talk directly to web, _not_ the engine. Placing here in the `engine-client` as we don't have enough
@@ -16,7 +19,7 @@ export class EngineWebClient extends EngineBaseClient {
   async getIpBlockStatus(): Promise<GetEngineIpBlockStatusResponse> {
     return (
       this.axiosInstance
-        // Use the /time endpoint and listen to 403 responses
+        // Use the /ip endpoint and listen to 403 responses
         .get(`${this.opts.url}/ip`, {
           // IP checks go through Cloudflare, which uses allow-origin as *, so withCredentials needs to be false
           withCredentials: false,
@@ -34,6 +37,23 @@ export class EngineWebClient extends EngineBaseClient {
           return resData.reason === 'ip_query_only' ? 'query_only' : 'blocked';
         })
     );
+  }
+
+  /**
+   * Retrieves the caller's country code as detected by the gateway, sourced
+   * from the `x-nado-country` response header on `/ip`. Returns `null` when
+   * the gateway does not provide it (e.g. local environments).
+   *
+   * Useful for region-based UI gating such as geoblocking trading competitions.
+   */
+  async getCountryCode(): Promise<GetEngineCountryCodeResponse> {
+    const res = await this.axiosInstance.get(`${this.opts.url}/ip`, {
+      // IP checks go through Cloudflare, which uses allow-origin as *, so withCredentials needs to be false
+      withCredentials: false,
+    });
+
+    const rawCountry = res.headers?.[COUNTRY_HEADER] as string | undefined;
+    return rawCountry ?? null;
   }
 
   /**

--- a/packages/engine-client/src/types/clientQueryTypes.ts
+++ b/packages/engine-client/src/types/clientQueryTypes.ts
@@ -256,6 +256,14 @@ export type GetEngineInsuranceResponse = BigNumber;
  */
 export type GetEngineIpBlockStatusResponse = 'query_only' | 'blocked' | null;
 
+/**
+ * ISO 3166-1 alpha-2 country code detected by the gateway (e.g. `'US'`, `'NO'`),
+ * or `null` if the gateway did not provide one (e.g. local environments).
+ *
+ * Suitable for region-based UI gating such as geoblocking trading competitions.
+ */
+export type GetEngineCountryCodeResponse = string | null;
+
 export interface GetEngineMaxMintNlpAmountParams extends Subaccount {
   // If not given, engine defaults to true (leverage/borrow enabled)
   spotLeverage?: boolean;


### PR DESCRIPTION
This pull request adds support for retrieving the user's country code as detected by the gateway, enabling region-based UI gating such as geoblocking. The main changes include adding a new method to the `EngineWebClient` for fetching the country code, updating the type definitions, and introducing corresponding tests.

**New country code detection support:**

* Added a new method `getCountryCode` to `EngineWebClient` that retrieves the ISO 3166-1 alpha-2 country code from the `x-nado-country` response header on the `/ip` endpoint. Returns `null` if not available.
* Introduced the `GetEngineCountryCodeResponse` type (`string | null`) in `clientQueryTypes.ts` to represent the country code or absence thereof.
* Added a constant `COUNTRY_HEADER` for the response header key in `EngineWebClient.ts`.

**Testing:**

* Added a test in `query.test.ts` to verify that `getCountryCode` returns a valid ISO country code or `null`.

**Other improvements:**

* Fixed a comment in `getIpBlockStatus` to clarify that the `/ip` endpoint is used (not `/time`).