### PR TITLE
Add avgPrice support to max order size query

### DIFF
--- a/packages/engine-client/src/EngineQueryClient.ts
+++ b/packages/engine-client/src/EngineQueryClient.ts
@@ -450,6 +450,10 @@ export class EngineQueryClient extends EngineBaseClient {
     const baseResponse = await this.query('max_order_size', {
       direction: params.side,
       price_x18: toIntegerString(addDecimals(params.price)),
+      avg_price_x18:
+        params.avgPrice != null
+          ? toIntegerString(addDecimals(params.avgPrice))
+          : null,
       product_id: params.productId,
       sender: subaccountToHex({
         subaccountOwner: params.subaccountOwner,

--- a/packages/engine-client/src/types/clientQueryTypes.ts
+++ b/packages/engine-client/src/types/clientQueryTypes.ts
@@ -213,6 +213,9 @@ export interface GetEngineMarketPricesResponse {
 
 export interface GetEngineMaxOrderSizeParams extends Subaccount {
   price: BigNumber;
+  // Optional average execution price for multi-price orders
+  // For longs, must be >= `price`; for shorts, <= `price`. Defaults to `price` when omitted.
+  avgPrice?: BigNumber;
   productId: number;
   // Note: When `reduceOnly` is true, `side` must be opposite of the current position, otherwise it returns 0.
   side: BalanceSide;

--- a/packages/engine-client/src/types/serverQueryTypes.ts
+++ b/packages/engine-client/src/types/serverQueryTypes.ts
@@ -87,6 +87,9 @@ export interface EngineServerMaxOrderSizeQueryParams {
   sender: string;
   product_id: number;
   price_x18: string;
+  // Optional average execution price in x18 units.
+  // If not given, engine uses `price_x18` for both health stress and cost basis.
+  avg_price_x18: string | null;
   // Note: When `reduce_only` is true, `direction` must be opposite of the current position, otherwise it returns 0.
   direction: 'long' | 'short';
   // If not given, engine defaults to true (leverage/borrow enabled)


### PR DESCRIPTION
Adds SDK support for passing `avgPrice` to the `max_order_size` query. The SDK now serializes it as `avg_price_x18` when provided, and sends `null` when omitted so existing backend defaults are preserved