### PR TITLE
Fix copilot symlink: AGENT.md > AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,1 @@
-../AGENT.md
+../AGENTS.md


### PR DESCRIPTION
Fix broken symlink `.github/copilot-instructions.md` pointing to `../AGENT.md` (nonexistent). Updated to `../AGENTS.md`.