### PR TITLE
update trading comp types

### DIFF
--- a/packages/indexer-client/src/types/clientTypes.ts
+++ b/packages/indexer-client/src/types/clientTypes.ts
@@ -581,7 +581,11 @@ export interface IndexerSocialAccountInfo {
 export interface IndexerLeaderboardTrackPosition {
   value: BigNumber;
   rank: BigNumber;
-  qualificationStatus: 'qualified' | 'insufficient_account_value';
+  qualificationStatus:
+    | 'qualified'
+    | 'insufficient_account_value'
+    | 'insufficient_volume'
+    | 'insufficient_account_value_and_volume';
 }
 
 export interface IndexerLeaderboardParticipant {

--- a/packages/indexer-client/src/types/serverModelTypes.ts
+++ b/packages/indexer-client/src/types/serverModelTypes.ts
@@ -260,7 +260,11 @@ export interface IndexerServerSocialAccount {
 export interface IndexerServerLeaderboardTrackPosition {
   value: string;
   rank: string;
-  qualification_status: 'qualified' | 'insufficient_account_value';
+  qualification_status:
+    | 'qualified'
+    | 'insufficient_account_value'
+    | 'insufficient_volume'
+    | 'insufficient_account_value_and_volume';
 }
 
 export interface IndexerServerLeaderboardContestTrack {


### PR DESCRIPTION
This pull request updates the leaderboard qualification status types in both client and server model definitions to support more detailed qualification reasons. This allows the system to represent additional cases where a participant may not qualify, improving clarity and consistency between client and server.

**Leaderboard qualification status enhancements:**

* Expanded the `qualificationStatus` field in `IndexerLeaderboardTrackPosition` (client type) to include `'insufficient_volume'` and `'insufficient_account_value_and_volume'`, in addition to the existing statuses.
* Expanded the `qualification_status` field in `IndexerServerLeaderboardTrackPosition` (server type) with the same new statuses to keep client and server models aligned.