### PR TITLE
patch trading comp track interface

### DIFF
--- a/apps/e2e/src/indexer-client/leaderboardTests.test.ts
+++ b/apps/e2e/src/indexer-client/leaderboardTests.test.ts
@@ -56,10 +56,7 @@ function assertLeaderboardContestTrackShape(
   assertNumber(track.trackId, `${label}.trackId`);
   assertDefined(track.rankType, `${label}.rankType`);
   assertDefined(track.sortOrder, `${label}.sortOrder`);
-  assertBigNumberFinite(
-    track.minRequiredAccountValue,
-    `${label}.minRequiredAccountValue`,
-  );
+  assertBigNumberFinite(track.threshold, `${label}.threshold`);
 }
 
 function assertLeaderboardContestShape(

--- a/packages/indexer-client/src/dataMappers.ts
+++ b/packages/indexer-client/src/dataMappers.ts
@@ -307,7 +307,7 @@ export function mapIndexerLeaderboardContest(
       trackId: track.track_id,
       rankType: track.rank_type,
       sortOrder: track.sort_order,
-      minRequiredAccountValue: toBigNumber(track.threshold),
+      threshold: toBigNumber(track.threshold),
     })),
   };
 }

--- a/packages/indexer-client/src/types/clientTypes.ts
+++ b/packages/indexer-client/src/types/clientTypes.ts
@@ -660,8 +660,8 @@ export interface IndexerLeaderboardContestTrack {
   trackId: number;
   rankType: IndexerLeaderboardRankType;
   sortOrder: 'ASC' | 'DESC';
-  // Float indicating the min account value required to qualify for this track e.g: 250.0
-  minRequiredAccountValue: BigNumber;
+  // Float indicating the min value required to qualify for this track e.g: 250.0
+  threshold: BigNumber;
 }
 
 export interface IndexerLeaderboardContest {


### PR DESCRIPTION
This pull request updates the naming of a property in the leaderboard contest track data model from `minRequiredAccountValue` to `threshold` to improve clarity and consistency across the codebase. The change is applied throughout type definitions, data mapping, and test assertions.

**Leaderboard contest track property renaming:**

* Renamed the `minRequiredAccountValue` property to `threshold` in the `IndexerLeaderboardContestTrack` interface in `clientTypes.ts` for improved clarity and alignment with backend naming.
* Updated the `mapIndexerLeaderboardContest` data mapper to use the new `threshold` property instead of `minRequiredAccountValue`.
* Modified test assertions in `leaderboardTests.test.ts` to check the `threshold` property instead of `minRequiredAccountValue`.