### PR TITLE
add fund rate history query

### DIFF
--- a/apps/e2e/src/indexer-client/marketsQueries.test.ts
+++ b/apps/e2e/src/indexer-client/marketsQueries.test.ts
@@ -17,6 +17,7 @@ import { delay } from '../utils/delay';
 import { createTestContext } from '../utils/runWithContext';
 import {
   assertCandlestickShape,
+  assertFundingRateHistoryEntryShape,
   assertFundingRateShape,
   assertMarketSnapshotShape,
   assertPerpPricesShape,
@@ -67,6 +68,59 @@ void describe(
       assertRecord(fundingRates, 'fundingRates');
       for (const rate of Object.values(fundingRates)) {
         assertFundingRateShape(rate, 'fundingRates entry');
+      }
+    });
+
+    void test('getFundingRateHistory returns ascending historical rates', async () => {
+      const limit = 5;
+      const fundingRateHistory = await client.getFundingRateHistory({
+        productId: TEST_PRODUCT_IDS.PERP_BTC,
+        limit,
+      });
+
+      debugPrint('Funding rate history', fundingRateHistory);
+      assertArray(fundingRateHistory, 'fundingRateHistory');
+      assert.ok(
+        fundingRateHistory.length <= limit,
+        'should return at most limit entries',
+      );
+      assertArrayElements(
+        fundingRateHistory,
+        assertFundingRateHistoryEntryShape,
+        'fundingRateHistory',
+      );
+
+      for (let i = 1; i < fundingRateHistory.length; i++) {
+        assert.ok(
+          fundingRateHistory[i].timestamp.gte(
+            fundingRateHistory[i - 1].timestamp,
+          ),
+          'entries should be ordered ascending by timestamp',
+        );
+      }
+    });
+
+    void test('getFundingRateHistory supports a start time window', async () => {
+      const startTimeInclusive = nowInSeconds() - TimeInSeconds.DAY * 7;
+      const fundingRateHistory = await client.getFundingRateHistory({
+        productId: TEST_PRODUCT_IDS.PERP_BTC,
+        startTimeInclusive,
+        limit: 5,
+      });
+
+      debugPrint('Funding rate history (windowed)', fundingRateHistory);
+      assertArray(fundingRateHistory, 'fundingRateHistory');
+      assertArrayElements(
+        fundingRateHistory,
+        assertFundingRateHistoryEntryShape,
+        'fundingRateHistory',
+      );
+
+      for (const entry of fundingRateHistory) {
+        assert.ok(
+          entry.timestamp.gte(startTimeInclusive),
+          'entries should not predate startTimeInclusive',
+        );
       }
     });
 

--- a/apps/e2e/src/utils/shapeAssertions.ts
+++ b/apps/e2e/src/utils/shapeAssertions.ts
@@ -274,6 +274,18 @@ export function assertFundingRateShape(
   assertBigNumberFinite(rate.updateTime, `${label}.updateTime`);
 }
 
+/**
+ * Validates the shape of a historical funding rate entry.
+ */
+export function assertFundingRateHistoryEntryShape(
+  entry: { productId: number; timestamp: unknown; fundingRateFrac: unknown },
+  label: string,
+): void {
+  assertNumber(entry.productId, `${label}.productId`);
+  assertBigNumberFinite(entry.timestamp, `${label}.timestamp`);
+  assertBigNumberFinite(entry.fundingRateFrac, `${label}.fundingRateFrac`);
+}
+
 // ---------------------------------------------------------------------------
 // Market snapshot shape
 // ---------------------------------------------------------------------------

--- a/packages/indexer-client/src/IndexerBaseClient.ts
+++ b/packages/indexer-client/src/IndexerBaseClient.ts
@@ -27,6 +27,7 @@ import {
   mapIndexerEvent,
   mapIndexerEventWithTx,
   mapIndexerFundingRate,
+  mapIndexerFundingRateHistory,
   mapIndexerLeaderboardContest,
   mapIndexerLeaderboardPosition,
   mapIndexerLeaderboardRegistration,
@@ -56,6 +57,8 @@ import {
   GetIndexerEventsResponse,
   GetIndexerFastWithdrawalSignatureParams,
   GetIndexerFastWithdrawalSignatureResponse,
+  GetIndexerFundingRateHistoryParams,
+  GetIndexerFundingRateHistoryResponse,
   GetIndexerFundingRateParams,
   GetIndexerFundingRateResponse,
   GetIndexerInterestFundingPaymentsParams,
@@ -285,6 +288,28 @@ export class IndexerBaseClient {
     });
 
     return mapValues(baseResponse, mapIndexerFundingRate);
+  }
+
+  /**
+   * Retrieves a perp product's historical (realized hourly) funding rates,
+   * ordered ascending by timestamp, where 1 = 100%.
+   *
+   * To paginate forward, pass the last entry's `timestamp + 1` as the next
+   * request's `startTimeInclusive`.
+   *
+   * @param params
+   */
+  async getFundingRateHistory(
+    params: GetIndexerFundingRateHistoryParams,
+  ): Promise<GetIndexerFundingRateHistoryResponse> {
+    const baseResponse = await this.query('funding_rate_history', {
+      product_id: params.productId,
+      start_time: params.startTimeInclusive,
+      end_time: params.endTimeInclusive,
+      limit: params.limit,
+    });
+
+    return baseResponse.funding_rates.map(mapIndexerFundingRateHistory);
   }
 
   /**

--- a/packages/indexer-client/src/dataMappers.ts
+++ b/packages/indexer-client/src/dataMappers.ts
@@ -20,6 +20,7 @@ import {
   IndexerEvent,
   IndexerEventWithTx,
   IndexerFundingRate,
+  IndexerFundingRateHistoryEntry,
   IndexerLeaderboardContest,
   IndexerLeaderboardParticipant,
   IndexerLeaderboardRegistration,
@@ -35,6 +36,7 @@ import {
   IndexerServerCandlestick,
   IndexerServerEvent,
   IndexerServerFundingRate,
+  IndexerServerFundingRateHistoryEntry,
   IndexerServerLeaderboardContest,
   IndexerServerLeaderboardPosition,
   IndexerServerLeaderboardRegistration,
@@ -231,6 +233,16 @@ export function mapIndexerFundingRate(
     fundingRate: removeDecimals(fundingRate.funding_rate_x18),
     updateTime: toBigNumber(fundingRate.update_time),
     productId: fundingRate.product_id,
+  };
+}
+
+export function mapIndexerFundingRateHistory(
+  entry: IndexerServerFundingRateHistoryEntry,
+): IndexerFundingRateHistoryEntry {
+  return {
+    productId: entry.product_id,
+    timestamp: toBigNumber(entry.timestamp),
+    fundingRateFrac: removeDecimals(entry.funding_rate_frac_x18),
   };
 }
 

--- a/packages/indexer-client/src/types/clientTypes.ts
+++ b/packages/indexer-client/src/types/clientTypes.ts
@@ -195,6 +195,44 @@ export type GetIndexerMultiProductFundingRatesResponse = Record<
 >;
 
 /**
+ * Funding rate history
+ */
+
+export interface GetIndexerFundingRateHistoryParams {
+  productId: number;
+  /**
+   * Unix epoch in seconds, inclusive lower bound. Only rates with `timestamp >= startTimeInclusive`
+   * are returned, paging forward from that time. When omitted, the most recent `limit` rates are returned.
+   */
+  startTimeInclusive?: number;
+  /**
+   * Unix epoch in seconds, inclusive upper bound. Only rates with `timestamp <= endTimeInclusive`
+   * are returned. Defaults to the current time.
+   */
+  endTimeInclusive?: number;
+  /** Max number of rates to return. Defaults to 100, max 1000. */
+  limit?: number;
+}
+
+export interface IndexerFundingRateHistoryEntry {
+  productId: number;
+  // Seconds
+  timestamp: BigNumber;
+  /**
+   * Realized hourly funding rate at this tick, where 1 = 100%.
+   * Multiply by 24 for the daily equivalent.
+   */
+  fundingRateFrac: BigNumber;
+}
+
+/**
+ * Entries are always ordered ascending by `timestamp`. To paginate forward,
+ * pass the last entry's `timestamp + 1` as the next request's `startTimeInclusive`.
+ */
+export type GetIndexerFundingRateHistoryResponse =
+  IndexerFundingRateHistoryEntry[];
+
+/**
  * Candlesticks
  */
 

--- a/packages/indexer-client/src/types/serverTypes.ts
+++ b/packages/indexer-client/src/types/serverTypes.ts
@@ -58,6 +58,14 @@ export interface IndexerServerFundingRatesParams {
   product_ids: number[];
 }
 
+export interface IndexerServerFundingRateHistoryParams {
+  product_id: number;
+  start_time?: number | string;
+  end_time?: number | string;
+  // Max number of rates to return. Defaults to 100, max 1000.
+  limit?: number;
+}
+
 export interface IndexerServerPriceParams {
   product_id: number;
 }
@@ -245,6 +253,7 @@ export interface IndexerServerQueryRequestByType {
   events: IndexerServerEventsParams;
   fast_withdrawal_signature: IndexerServerFastWithdrawalSignatureParams;
   funding_rate: IndexerServerFundingRateParams;
+  funding_rate_history: IndexerServerFundingRateHistoryParams;
   funding_rates: IndexerServerFundingRatesParams;
   interest_and_funding: IndexerServerInterestFundingParams;
   leaderboard: IndexerServerLeaderboardParams;
@@ -313,6 +322,19 @@ export type IndexerServerFundingRatesResponse = Record<
   string,
   IndexerServerFundingRate
 >;
+
+export interface IndexerServerFundingRateHistoryEntry {
+  product_id: number;
+  // Epoch time in seconds of the settlement tick this funding rate was recorded at.
+  timestamp: string;
+  // Realized hourly funding rate at this tick, multiplied by 10^18 (% = rate * 100).
+  funding_rate_frac_x18: string;
+}
+
+export interface IndexerServerFundingRateHistoryResponse {
+  // Always ascending by timestamp.
+  funding_rates: IndexerServerFundingRateHistoryEntry[];
+}
 
 export interface IndexerServerPerpPrices {
   product_id: number;
@@ -493,6 +515,7 @@ export interface IndexerServerQueryResponseByType {
   events: IndexerServerEventsResponse;
   fast_withdrawal_signature: IndexerServerFastWithdrawalSignatureResponse;
   funding_rate: IndexerServerFundingRateResponse;
+  funding_rate_history: IndexerServerFundingRateHistoryResponse;
   funding_rates: IndexerServerFundingRatesResponse;
   interest_and_funding: IndexerServerInterestFundingResponse;
   leaderboard: IndexerServerLeaderboardResponse;


### PR DESCRIPTION
This pull request adds support for retrieving and validating historical funding rate data for perpetual products in the indexer client. It introduces new client methods, data types, and tests to enable fetching, mapping, and asserting the shape of funding rate history entries, including support for time window filtering and pagination.

**Indexer client and API enhancements:**

* Added the `getFundingRateHistory` method to `IndexerBaseClient`, allowing retrieval of historical funding rates with support for time windows and pagination.
* Introduced new request and response types for funding rate history in both client (`GetIndexerFundingRateHistoryParams`, `GetIndexerFundingRateHistoryResponse`, `IndexerFundingRateHistoryEntry`) and server (`IndexerServerFundingRateHistoryParams`, `IndexerServerFundingRateHistoryEntry`, `IndexerServerFundingRateHistoryResponse`) type definitions. [[1]](diffhunk://#diff-fc17e0b853cc30e2f401b8c780c55d766f670437348dadcc889b913479758b02R197-R234) [[2]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R61-R68) [[3]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R326-R338) [[4]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R518)
* Updated query request/response mappings to include the new `funding_rate_history` endpoint. [[1]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R256) [[2]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R518)

**Data mapping and validation:**

* Added the `mapIndexerFundingRateHistory` function to map server funding rate history entries to client types.
* Implemented the `assertFundingRateHistoryEntryShape` test utility for validating funding rate history entries in tests.

**Testing:**

* Added end-to-end tests for `getFundingRateHistory`, verifying correct ordering, limiting, and time window support in `marketsQueries.test.ts`. [[1]](diffhunk://#diff-2e584a0568eb0761bcf5a5c49b43a59d93a52a3db8db74fb13a143127b892277R74-R126) [[2]](diffhunk://#diff-2e584a0568eb0761bcf5a5c49b43a59d93a52a3db8db74fb13a143127b892277R20)

These changes provide a robust foundation for working with historical funding rate data in the indexer client.

contributes to ENGW-197