### PR TITLE
docs: fix e2e setup instructions

### DIFF
--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -4,9 +4,9 @@
 
 Before running any tests, make sure to configure your environment and set up the test account:
 
-1. Copy `.env.example` into `.env` and fill out any appropriate values
+1. Copy `.env.example` into `.env` and fill out any appropriate values.
 
-2. Run the `bun account-setup` to mint and deposit tokens for the test account
+2. Run `bun fund` to mint and deposit tokens for the test account.
 
 ## E2E Tests
 


### PR DESCRIPTION
## Description

Fix incorrect E2E setup instructions by updating the referenced setup command.

## Changes

Replaced the non-existent `bun account-setup` command with the actual `bun fund` script.

## Verification

Checked the command flow through the repository:

- `apps/e2e/package.json`
  - confirmed available scripts
  - verified `fund` points to `src/scripts/fundSubaccount.ts`

- `apps/e2e/src/scripts/fundSubaccount.ts`
  - confirmed the `fund` script executes `ensureSubaccountFunded()`

- `apps/e2e/src/utils/ensureSubaccountFunded.ts`
  - confirmed the setup flow:
    - mints mock ERC20 tokens
    - approves allowance
    - deposits tokens into the test subaccount