### PR TITLE
patch e2e tests

### DIFF
--- a/packages/indexer-client/src/dataMappers.ts
+++ b/packages/indexer-client/src/dataMappers.ts
@@ -242,7 +242,7 @@ export function mapIndexerFundingRateHistory(
   return {
     productId: entry.product_id,
     timestamp: toBigNumber(entry.timestamp),
-    fundingRateFrac: removeDecimals(entry.funding_rate_frac_x18),
+    fundingRateFrac: removeDecimals(entry.funding_rate_x18),
   };
 }
 

--- a/packages/indexer-client/src/types/serverTypes.ts
+++ b/packages/indexer-client/src/types/serverTypes.ts
@@ -328,7 +328,7 @@ export interface IndexerServerFundingRateHistoryEntry {
   // Epoch time in seconds of the settlement tick this funding rate was recorded at.
   timestamp: string;
   // Realized hourly funding rate at this tick, multiplied by 10^18 (% = rate * 100).
-  funding_rate_frac_x18: string;
+  funding_rate_x18: string;
 }
 
 export interface IndexerServerFundingRateHistoryResponse {


### PR DESCRIPTION
This pull request updates the funding rate field naming in the indexer client data mapping and types for consistency with backend changes. The main changes are:

**Field renaming for funding rate:**

* In `packages/indexer-client/src/types/serverTypes.ts`, the interface property `funding_rate_frac_x18` was renamed to `funding_rate_x18` in `IndexerServerFundingRateHistoryEntry` to match backend naming.
* In `packages/indexer-client/src/dataMappers.ts`, the mapping function `mapIndexerFundingRateHistory` was updated to use the new `funding_rate_x18` field instead of the old `funding_rate_frac_x18`.