### PR TITLE
add xpoints query

### DIFF
--- a/apps/e2e/src/indexer-client/subaccountQueries.test.ts
+++ b/apps/e2e/src/indexer-client/subaccountQueries.test.ts
@@ -440,5 +440,51 @@ void describe(
         'points.pointsPerEpoch',
       );
     });
+
+    void test('getXPoints returns xPoints for the wallet address', async () => {
+      const xPoints = await client.getXPoints({
+        address: subaccount.subaccountOwner as Address,
+      });
+
+      debugPrint('XPoints', xPoints);
+      assertDefined(xPoints, 'xPoints');
+      assertDefined(xPoints.allTimePoints, 'xPoints.allTimePoints');
+      assertBigNumberFinite(
+        xPoints.allTimePoints.totalPoints,
+        'xPoints.allTimePoints.totalPoints',
+      );
+      assertNumber(xPoints.allTimePoints.rank, 'xPoints.allTimePoints.rank');
+      assertArray(xPoints.allTimePoints.quests, 'xPoints.allTimePoints.quests');
+      assertArrayElements(
+        xPoints.allTimePoints.quests,
+        (quest, label) => {
+          assertString(quest.questType, `${label}.questType`);
+          assertBigNumberFinite(quest.points, `${label}.points`);
+        },
+        'xPoints.allTimePoints.quests',
+      );
+      assertArray(xPoints.pointsPerEpoch, 'xPoints.pointsPerEpoch');
+      assertArrayElements(
+        xPoints.pointsPerEpoch,
+        (epoch, label) => {
+          assertNumber(epoch.epoch, `${label}.epoch`);
+          assertString(epoch.description, `${label}.description`);
+          assertBigNumberFinite(epoch.startTime, `${label}.startTime`);
+          assertBigNumberFinite(epoch.endTime, `${label}.endTime`);
+          assertBigNumberFinite(epoch.totalPoints, `${label}.totalPoints`);
+          assertNumber(epoch.rank, `${label}.rank`);
+          assertArray(epoch.quests, `${label}.quests`);
+          assertArrayElements(
+            epoch.quests,
+            (quest, questLabel) => {
+              assertString(quest.questType, `${questLabel}.questType`);
+              assertBigNumberFinite(quest.points, `${questLabel}.points`);
+            },
+            `${label}.quests`,
+          );
+        },
+        'xPoints.pointsPerEpoch',
+      );
+    });
   },
 );

--- a/packages/indexer-client/README.md
+++ b/packages/indexer-client/README.md
@@ -57,7 +57,7 @@ const trades = await indexer.getPaginatedSubaccountMatchEvents({ ... });
 
 ### Leaderboards & Analytics
 
-`getLeaderboard`, `getLeaderboardParticipant`, `getMakerStatistics`, `getPoints`, `getReferralCode`.
+`getLeaderboard`, `getLeaderboardParticipant`, `getMakerStatistics`, `getPoints`, `getXPoints`, `getReferralCode`.
 
 ### NLP
 

--- a/packages/indexer-client/src/IndexerBaseClient.ts
+++ b/packages/indexer-client/src/IndexerBaseClient.ts
@@ -110,6 +110,8 @@ import {
   GetIndexerV2SymbolsResponse,
   GetIndexerV2TickersParams,
   GetIndexerV2TickersResponse,
+  GetIndexerXPointsParams,
+  GetIndexerXPointsResponse,
   IndexerEventWithTx,
   IndexerMatchEvent,
   IndexerOraclePrice,
@@ -933,6 +935,44 @@ export class IndexerBaseClient {
         points: toBigNumber(baseResponse.all_time_points.points),
         rank: baseResponse.all_time_points.rank,
         tier: baseResponse.all_time_points.tier,
+      },
+    };
+  }
+
+  /**
+   * Retrieves xPoints information (Nado x xStocks points program) for a given address,
+   * including per-epoch points, all-time points, and per-quest breakdowns.
+   * @param params
+   */
+  async getXPoints(
+    params: GetIndexerXPointsParams,
+  ): Promise<GetIndexerXPointsResponse> {
+    const baseResponse = await this.query('nado_xpoints', {
+      address: params.address,
+    });
+
+    const mapQuests = (
+      quests: typeof baseResponse.all_time_points.quests,
+    ): GetIndexerXPointsResponse['allTimePoints']['quests'] =>
+      quests.map((quest) => ({
+        questType: quest.quest_type,
+        points: toBigNumber(quest.points),
+      }));
+
+    return {
+      pointsPerEpoch: baseResponse.points_per_epoch.map((epoch) => ({
+        epoch: epoch.epoch,
+        description: epoch.description,
+        startTime: toBigNumber(epoch.start_time),
+        endTime: toBigNumber(epoch.end_time),
+        totalPoints: toBigNumber(epoch.total_points),
+        rank: epoch.rank,
+        quests: mapQuests(epoch.quests),
+      })),
+      allTimePoints: {
+        totalPoints: toBigNumber(baseResponse.all_time_points.total_points),
+        rank: baseResponse.all_time_points.rank,
+        quests: mapQuests(baseResponse.all_time_points.quests),
       },
     };
   }

--- a/packages/indexer-client/src/types/clientTypes.ts
+++ b/packages/indexer-client/src/types/clientTypes.ts
@@ -861,6 +861,41 @@ export interface GetIndexerPointsResponse {
 }
 
 /**
+ * Nado XPoints (Nado x xStocks points program)
+ */
+
+export interface GetIndexerXPointsParams {
+  address: Address;
+}
+
+export interface IndexerXPointsQuest {
+  /** Quest identifier, e.g. `ProtocolDepositBoost` or `ProtocolTieredVolumeBoost` */
+  questType: string;
+  points: BigNumber;
+}
+
+export interface IndexerXPointsEpoch {
+  epoch: number;
+  description: string;
+  startTime: BigNumber;
+  endTime: BigNumber;
+  totalPoints: BigNumber;
+  rank: number;
+  quests: IndexerXPointsQuest[];
+}
+
+export interface IndexerXPointsAllTime {
+  totalPoints: BigNumber;
+  rank: number;
+  quests: IndexerXPointsQuest[];
+}
+
+export interface GetIndexerXPointsResponse {
+  pointsPerEpoch: IndexerXPointsEpoch[];
+  allTimePoints: IndexerXPointsAllTime;
+}
+
+/**
  * V2 Tickers
  */
 

--- a/packages/indexer-client/src/types/serverTypes.ts
+++ b/packages/indexer-client/src/types/serverTypes.ts
@@ -242,6 +242,10 @@ export interface IndexerServerPointsParams {
   address: string;
 }
 
+export interface IndexerServerXPointsParams {
+  address: string;
+}
+
 // Request
 export interface IndexerServerQueryRequestByType {
   account_snapshots: IndexerServerMultiSubaccountSnapshotsParams;
@@ -277,6 +281,7 @@ export interface IndexerServerQueryRequestByType {
   nlp_snapshots: IndexerServerNlpSnapshotsParams;
   private_alpha_choice: IndexerServerPrivateAlphaChoiceParams;
   nado_points: IndexerServerPointsParams;
+  nado_xpoints: IndexerServerXPointsParams;
   social_connect: IndexerServerSocialConnectParams;
   list_social_accounts: IndexerServerListSocialAccountsParams;
   revoke_social_account: IndexerServerRevokeSocialAccountParams;
@@ -498,6 +503,32 @@ export interface IndexerServerPointsResponse {
   all_time_points: IndexerServerAllTimePoints;
 }
 
+export interface IndexerServerXPointsQuest {
+  quest_type: string;
+  points: string;
+}
+
+export interface IndexerServerXPointsEpoch {
+  epoch: number;
+  description: string;
+  start_time: string;
+  end_time: string;
+  total_points: string;
+  rank: number;
+  quests: IndexerServerXPointsQuest[];
+}
+
+export interface IndexerServerXPointsAllTime {
+  total_points: string;
+  rank: number;
+  quests: IndexerServerXPointsQuest[];
+}
+
+export interface IndexerServerXPointsResponse {
+  points_per_epoch: IndexerServerXPointsEpoch[];
+  all_time_points: IndexerServerXPointsAllTime;
+}
+
 export interface IndexerServerSocialConnectResponse {
   url: string;
 }
@@ -541,6 +572,7 @@ export interface IndexerServerQueryResponseByType {
   nlp_snapshots: IndexerServerNlpSnapshotsResponse;
   private_alpha_choice: IndexerServerPrivateAlphaChoiceResponse;
   nado_points: IndexerServerPointsResponse;
+  nado_xpoints: IndexerServerXPointsResponse;
   social_connect: IndexerServerSocialConnectResponse;
   list_social_accounts: IndexerServerSocialAccountsResponse;
   revoke_social_account: IndexerServerSocialAccountsResponse;


### PR DESCRIPTION
This pull request adds support for retrieving "xPoints" (Nado x xStocks points program) from the indexer client, including both API and type definitions, a new client method, and corresponding test coverage. It also updates the documentation to reflect the new functionality.

**Indexer client enhancements:**

* Added a new method `getXPoints` to `IndexerBaseClient` for retrieving xPoints information for a given address, including per-epoch and all-time points with quest breakdowns.
* Introduced new TypeScript types and interfaces for xPoints requests and responses in `clientTypes.ts` and `serverTypes.ts`. [[1]](diffhunk://#diff-fc17e0b853cc30e2f401b8c780c55d766f670437348dadcc889b913479758b02R863-R899) [[2]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R245-R248) [[3]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R284) [[4]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R506-R531) [[5]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R575)
* Updated imports in `IndexerBaseClient.ts` to include new xPoints types.

**Documentation and testing:**

* Updated the `README.md` to document the new `getXPoints` method.
* Added an end-to-end test to verify the new `getXPoints` functionality and validate the structure of returned data.

contributes to ENGW-201