### PR TITLE
add cash incentives query

### DIFF
--- a/apps/e2e/src/indexer-client/subaccountQueries.test.ts
+++ b/apps/e2e/src/indexer-client/subaccountQueries.test.ts
@@ -486,5 +486,81 @@ void describe(
         'xPoints.pointsPerEpoch',
       );
     });
+
+    void test('getCashIncentives returns platform volume and rewards per event', async () => {
+      const cashIncentives = await client.getCashIncentives({
+        address: subaccount.subaccountOwner as Address,
+      });
+
+      debugPrint('CashIncentives', cashIncentives);
+      assertDefined(cashIncentives, 'cashIncentives');
+
+      assertArray(cashIncentives.events, 'cashIncentives.events');
+      assertArrayElements(
+        cashIncentives.events,
+        (event, label) => {
+          assertDefined(event.metadata, `${label}.metadata`);
+          assertNumber(event.metadata.eventId, `${label}.metadata.eventId`);
+          assertString(
+            event.metadata.description,
+            `${label}.metadata.description`,
+          );
+          assertBigNumberFinite(
+            event.metadata.epochStart,
+            `${label}.metadata.epochStart`,
+          );
+          assertBigNumberFinite(
+            event.metadata.epochEnd,
+            `${label}.metadata.epochEnd`,
+          );
+          assertBigNumberNonNegative(
+            event.metadata.maxVolume,
+            `${label}.metadata.maxVolume`,
+          );
+          assertBigNumberNonNegative(
+            event.metadata.maxReward,
+            `${label}.metadata.maxReward`,
+          );
+          assertBigNumberNonNegative(
+            event.metadata.minVolume,
+            `${label}.metadata.minVolume`,
+          );
+          assertBigNumberNonNegative(
+            event.metadata.minReward,
+            `${label}.metadata.minReward`,
+          );
+
+          assertDefined(event.platform, `${label}.platform`);
+          assertBigNumberNonNegative(
+            event.platform.platformVolume,
+            `${label}.platform.platformVolume`,
+          );
+          assertBigNumberNonNegative(
+            event.platform.unlockedReward,
+            `${label}.platform.unlockedReward`,
+          );
+
+          assertDefined(event.wallet, `${label}.wallet`);
+          assertBigNumberNonNegative(
+            event.wallet.reward,
+            `${label}.wallet.reward`,
+          );
+        },
+        'cashIncentives.events',
+      );
+
+      assertDefined(
+        cashIncentives.walletSummary,
+        'cashIncentives.walletSummary',
+      );
+      assertBigNumberNonNegative(
+        cashIncentives.walletSummary.totalReward,
+        'cashIncentives.walletSummary.totalReward',
+      );
+      assertBigNumberNonNegative(
+        cashIncentives.walletSummary.claimableReward,
+        'cashIncentives.walletSummary.claimableReward',
+      );
+    });
   },
 );

--- a/packages/indexer-client/src/IndexerBaseClient.ts
+++ b/packages/indexer-client/src/IndexerBaseClient.ts
@@ -49,6 +49,8 @@ import {
   GetIndexerBacklogResponse,
   GetIndexerCandlesticksParams,
   GetIndexerCandlesticksResponse,
+  GetIndexerCashIncentivesParams,
+  GetIndexerCashIncentivesResponse,
   GetIndexerEdgeCandlesticksParams,
   GetIndexerEdgeCandlesticksResponse,
   GetIndexerEdgeMarketSnapshotResponse,
@@ -973,6 +975,47 @@ export class IndexerBaseClient {
         totalPoints: toBigNumber(baseResponse.all_time_points.total_points),
         rank: baseResponse.all_time_points.rank,
         quests: mapQuests(baseResponse.all_time_points.quests),
+      },
+    };
+  }
+
+  /**
+   * Retrieves cash incentives information (platform volume and unlocked rewards) for a given wallet address.
+   * If no `eventId` is provided, the latest event is returned.
+   * @param params
+   */
+  async getCashIncentives(
+    params: GetIndexerCashIncentivesParams,
+  ): Promise<GetIndexerCashIncentivesResponse> {
+    const baseResponse = await this.query('cash_incentives', {
+      wallet_address: params.address,
+    });
+
+    return {
+      events: baseResponse.events.map((event) => ({
+        metadata: {
+          eventId: event.metadata.event_id,
+          description: event.metadata.description,
+          epochStart: toBigNumber(event.metadata.epoch_start),
+          epochEnd: toBigNumber(event.metadata.epoch_end),
+          maxVolume: removeDecimals(event.metadata.max_volume),
+          maxReward: removeDecimals(event.metadata.max_reward),
+          minVolume: removeDecimals(event.metadata.min_volume),
+          minReward: removeDecimals(event.metadata.min_reward),
+        },
+        platform: {
+          platformVolume: removeDecimals(event.platform.platform_volume),
+          unlockedReward: removeDecimals(event.platform.unlocked_reward),
+        },
+        wallet: {
+          reward: removeDecimals(event.wallet.reward),
+        },
+      })),
+      walletSummary: {
+        totalReward: removeDecimals(baseResponse.wallet_summary.total_reward),
+        claimableReward: removeDecimals(
+          baseResponse.wallet_summary.claimable_reward,
+        ),
       },
     };
   }

--- a/packages/indexer-client/src/types/clientTypes.ts
+++ b/packages/indexer-client/src/types/clientTypes.ts
@@ -896,6 +896,52 @@ export interface GetIndexerXPointsResponse {
 }
 
 /**
+ * Cash Incentives (platform volume and unlocked rewards)
+ */
+
+export interface GetIndexerCashIncentivesParams {
+  address: Address;
+}
+
+export interface IndexerCashIncentivesEventMetadata {
+  eventId: number;
+  description: string;
+  /** Unix timestamp in seconds */
+  epochStart: BigNumber;
+  /** Unix timestamp in seconds */
+  epochEnd: BigNumber;
+  maxVolume: BigNumber;
+  maxReward: BigNumber;
+  minVolume: BigNumber;
+  minReward: BigNumber;
+}
+
+export interface IndexerCashIncentivesEventPlatform {
+  platformVolume: BigNumber;
+  unlockedReward: BigNumber;
+}
+
+export interface IndexerCashIncentivesEventWallet {
+  reward: BigNumber;
+}
+
+export interface IndexerCashIncentivesEvent {
+  metadata: IndexerCashIncentivesEventMetadata;
+  platform: IndexerCashIncentivesEventPlatform;
+  wallet: IndexerCashIncentivesEventWallet;
+}
+
+export interface IndexerCashIncentivesWalletSummary {
+  totalReward: BigNumber;
+  claimableReward: BigNumber;
+}
+
+export interface GetIndexerCashIncentivesResponse {
+  events: IndexerCashIncentivesEvent[];
+  walletSummary: IndexerCashIncentivesWalletSummary;
+}
+
+/**
  * V2 Tickers
  */
 

--- a/packages/indexer-client/src/types/serverTypes.ts
+++ b/packages/indexer-client/src/types/serverTypes.ts
@@ -246,6 +246,10 @@ export interface IndexerServerXPointsParams {
   address: string;
 }
 
+export interface IndexerServerCashIncentivesParams {
+  wallet_address: string;
+}
+
 // Request
 export interface IndexerServerQueryRequestByType {
   account_snapshots: IndexerServerMultiSubaccountSnapshotsParams;
@@ -282,6 +286,7 @@ export interface IndexerServerQueryRequestByType {
   private_alpha_choice: IndexerServerPrivateAlphaChoiceParams;
   nado_points: IndexerServerPointsParams;
   nado_xpoints: IndexerServerXPointsParams;
+  cash_incentives: IndexerServerCashIncentivesParams;
   social_connect: IndexerServerSocialConnectParams;
   list_social_accounts: IndexerServerListSocialAccountsParams;
   revoke_social_account: IndexerServerRevokeSocialAccountParams;
@@ -529,6 +534,53 @@ export interface IndexerServerXPointsResponse {
   all_time_points: IndexerServerXPointsAllTime;
 }
 
+export interface IndexerServerCashIncentivesEventMetadata {
+  event_id: number;
+  description: string;
+  // UNIX timestamp in seconds
+  epoch_start: string;
+  // UNIX timestamp in seconds
+  epoch_end: string;
+  // x18 string
+  max_volume: string;
+  // x18 string
+  max_reward: string;
+  // x18 string
+  min_volume: string;
+  // x18 string
+  min_reward: string;
+}
+
+export interface IndexerServerCashIncentivesEventPlatform {
+  // x18 string
+  platform_volume: string;
+  // x18 string
+  unlocked_reward: string;
+}
+
+export interface IndexerServerCashIncentivesEventWallet {
+  // x18 string
+  reward: string;
+}
+
+export interface IndexerServerCashIncentivesEvent {
+  metadata: IndexerServerCashIncentivesEventMetadata;
+  platform: IndexerServerCashIncentivesEventPlatform;
+  wallet: IndexerServerCashIncentivesEventWallet;
+}
+
+export interface IndexerServerCashIncentivesWalletSummary {
+  // x18 string
+  total_reward: string;
+  // x18 string
+  claimable_reward: string;
+}
+
+export interface IndexerServerCashIncentivesResponse {
+  events: IndexerServerCashIncentivesEvent[];
+  wallet_summary: IndexerServerCashIncentivesWalletSummary;
+}
+
 export interface IndexerServerSocialConnectResponse {
   url: string;
 }
@@ -573,6 +625,7 @@ export interface IndexerServerQueryResponseByType {
   private_alpha_choice: IndexerServerPrivateAlphaChoiceResponse;
   nado_points: IndexerServerPointsResponse;
   nado_xpoints: IndexerServerXPointsResponse;
+  cash_incentives: IndexerServerCashIncentivesResponse;
   social_connect: IndexerServerSocialConnectResponse;
   list_social_accounts: IndexerServerSocialAccountsResponse;
   revoke_social_account: IndexerServerSocialAccountsResponse;


### PR DESCRIPTION
This pull request adds support for retrieving and handling cash incentives (platform volume and unlocked rewards) for a given wallet address in the indexer client. The main changes include implementing the `getCashIncentives` method, defining new types for the cash incentives data structures, and updating the server and client type definitions to support the new query.

**Cash Incentives Feature Implementation:**

- Added a new method `getCashIncentives` to `IndexerBaseClient`, which fetches and processes platform volume and unlocked rewards data for a wallet address.
- Introduced new client-side types in `clientTypes.ts` for cash incentives parameters, event metadata, platform/wallet data, and the response structure.

**Server and Query Type Updates:**

- Defined corresponding server-side types in `serverTypes.ts` for cash incentives queries, including request parameters, event structures, and response objects. [[1]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R249-R252) [[2]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R537-R583)
- Updated the server query type maps to include the new `cash_incentives` query. [[1]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R289) [[2]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R628)

**Testing:**

- Added a new test case to `subaccountQueries.test.ts` to verify that `getCashIncentives` returns the expected platform volume and rewards data per event and wallet summary.


contributes to ENGW-202 