### PR TITLE
feat(indexer-client): add portfolio query

### DIFF
--- a/apps/e2e/src/indexer-client/subaccountQueries.test.ts
+++ b/apps/e2e/src/indexer-client/subaccountQueries.test.ts
@@ -102,7 +102,7 @@ void describe(
       for (const period of periods) {
         const history = portfolio[period];
         assertDefined(history, `portfolio.${period}`);
-        assertBigNumberFinite(history.vlm, `portfolio.${period}.vlm`);
+        assertBigNumberFinite(history.volume, `portfolio.${period}.volume`);
         for (const key of ['accountValueHistory', 'pnlHistory'] as const) {
           assertArray(history[key], `portfolio.${period}.${key}`);
           assertArrayElements(

--- a/apps/e2e/src/indexer-client/subaccountQueries.test.ts
+++ b/apps/e2e/src/indexer-client/subaccountQueries.test.ts
@@ -82,6 +82,41 @@ void describe(
       }
     });
 
+    void test('getPortfolio returns value and PnL history across timeframes', async () => {
+      const portfolio = await client.getPortfolio({ subaccount });
+
+      debugPrint('Portfolio', portfolio);
+      assertDefined(portfolio, 'portfolio');
+
+      const periods = [
+        'day',
+        'week',
+        'month',
+        'allTime',
+        'perpDay',
+        'perpWeek',
+        'perpMonth',
+        'perpAllTime',
+      ] as const;
+
+      for (const period of periods) {
+        const history = portfolio[period];
+        assertDefined(history, `portfolio.${period}`);
+        assertBigNumberFinite(history.vlm, `portfolio.${period}.vlm`);
+        for (const key of ['accountValueHistory', 'pnlHistory'] as const) {
+          assertArray(history[key], `portfolio.${period}.${key}`);
+          assertArrayElements(
+            history[key],
+            (point, label) => {
+              assertBigNumberFinite(point.timestamp, `${label}.timestamp`);
+              assertBigNumberFinite(point.value, `${label}.value`);
+            },
+            `portfolio.${period}.${key}`,
+          );
+        }
+      }
+    });
+
     void test('getLinkedSignerWithRateLimit returns signer info', async () => {
       const linkedSigner = await client.getLinkedSignerWithRateLimit({
         subaccount,

--- a/packages/indexer-client/src/IndexerBaseClient.ts
+++ b/packages/indexer-client/src/IndexerBaseClient.ts
@@ -37,6 +37,7 @@ import {
   mapIndexerNlpSnapshot,
   mapIndexerOrder,
   mapIndexerPerpPrices,
+  mapIndexerPortfolio,
   mapIndexerProductPayment,
   mapIndexerServerProduct,
   mapIndexerV2Symbols,
@@ -99,6 +100,8 @@ import {
   GetIndexerPerpPricesResponse,
   GetIndexerPointsParams,
   GetIndexerPointsResponse,
+  GetIndexerPortfolioParams,
+  GetIndexerPortfolioResponse,
   GetIndexerPrivateAlphaChoiceParams,
   GetIndexerPrivateAlphaChoiceResponse,
   GetIndexerProductSnapshotsParams,
@@ -316,6 +319,23 @@ export class IndexerBaseClient {
     });
 
     return baseResponse.funding_rates.map(mapIndexerFundingRateHistory);
+  }
+
+  /**
+   * Retrieves a subaccount's account-value and PnL history across all
+   * timeframes, keyed by period. The value aggregates the cross-margin account
+   * plus every isolated child; the queried subaccount must be cross-margin.
+   *
+   * @param params
+   */
+  async getPortfolio(
+    params: GetIndexerPortfolioParams,
+  ): Promise<GetIndexerPortfolioResponse> {
+    const baseResponse = await this.query('portfolio', {
+      subaccount: subaccountToHex(params.subaccount),
+    });
+
+    return mapIndexerPortfolio(baseResponse);
   }
 
   /**

--- a/packages/indexer-client/src/dataMappers.ts
+++ b/packages/indexer-client/src/dataMappers.ts
@@ -17,6 +17,7 @@ import {
 } from '@nadohq/shared';
 import {
   Candlestick,
+  GetIndexerPortfolioResponse,
   IndexerEvent,
   IndexerEventWithTx,
   IndexerFundingRate,
@@ -31,6 +32,7 @@ import {
   IndexerOrder,
   IndexerPerpBalance,
   IndexerPerpPrices,
+  IndexerPortfolioPoint,
   IndexerProductPayment,
   IndexerServerBalance,
   IndexerServerCandlestick,
@@ -46,6 +48,8 @@ import {
   IndexerServerNlpSnapshot,
   IndexerServerOrder,
   IndexerServerPerpPrices,
+  IndexerServerPortfolioPoint,
+  IndexerServerPortfolioResponse,
   IndexerServerProduct,
   IndexerServerProductPayment,
   IndexerServerSnapshotsInterval,
@@ -244,6 +248,33 @@ export function mapIndexerFundingRateHistory(
     timestamp: toBigNumber(entry.timestamp),
     fundingRateFrac: removeDecimals(entry.funding_rate_x18),
   };
+}
+
+function mapIndexerPortfolioPoint([
+  timestamp,
+  value,
+]: IndexerServerPortfolioPoint): IndexerPortfolioPoint {
+  return {
+    timestamp: toBigNumber(timestamp),
+    value: toBigNumber(value),
+  };
+}
+
+export function mapIndexerPortfolio(
+  response: IndexerServerPortfolioResponse,
+): GetIndexerPortfolioResponse {
+  return Object.fromEntries(
+    response.map(([period, history]) => [
+      period,
+      {
+        accountValueHistory: history.accountValueHistory.map(
+          mapIndexerPortfolioPoint,
+        ),
+        pnlHistory: history.pnlHistory.map(mapIndexerPortfolioPoint),
+        vlm: toBigNumber(history.vlm),
+      },
+    ]),
+  ) as GetIndexerPortfolioResponse;
 }
 
 export function mapIndexerMakerStatistics(

--- a/packages/indexer-client/src/dataMappers.ts
+++ b/packages/indexer-client/src/dataMappers.ts
@@ -271,7 +271,7 @@ export function mapIndexerPortfolio(
           mapIndexerPortfolioPoint,
         ),
         pnlHistory: history.pnlHistory.map(mapIndexerPortfolioPoint),
-        vlm: toBigNumber(history.vlm),
+        volume: toBigNumber(history.vlm),
       },
     ]),
   ) as GetIndexerPortfolioResponse;

--- a/packages/indexer-client/src/types/clientTypes.ts
+++ b/packages/indexer-client/src/types/clientTypes.ts
@@ -274,7 +274,7 @@ export interface IndexerPortfolioHistory {
    */
   pnlHistory: IndexerPortfolioPoint[];
   // Total traded volume over the timeframe, USDT0-denominated.
-  vlm: BigNumber;
+  volume: BigNumber;
 }
 
 export type GetIndexerPortfolioResponse = Record<

--- a/packages/indexer-client/src/types/clientTypes.ts
+++ b/packages/indexer-client/src/types/clientTypes.ts
@@ -238,6 +238,51 @@ export type GetIndexerFundingRateHistoryResponse =
   IndexerFundingRateHistoryEntry[];
 
 /**
+ * Portfolio
+ */
+
+export interface GetIndexerPortfolioParams {
+  /**
+   * Cross-margin subaccount to query. Its value aggregates the cross-margin
+   * account plus every isolated child; isolated subaccounts are rejected.
+   */
+  subaccount: Subaccount;
+}
+
+export type IndexerPortfolioPeriod =
+  | 'day'
+  | 'week'
+  | 'month'
+  | 'allTime'
+  | 'perpDay'
+  | 'perpWeek'
+  | 'perpMonth'
+  | 'perpAllTime';
+
+export interface IndexerPortfolioPoint {
+  // Unix seconds
+  timestamp: BigNumber;
+  // USDT0-denominated
+  value: BigNumber;
+}
+
+export interface IndexerPortfolioHistory {
+  accountValueHistory: IndexerPortfolioPoint[];
+  /**
+   * Trading PnL over the timeframe, baseline-subtracted so the first visible
+   * point is `0`. Capital flows (deposits/withdrawals/transfers) are netted out.
+   */
+  pnlHistory: IndexerPortfolioPoint[];
+  // Total traded volume over the timeframe, USDT0-denominated.
+  vlm: BigNumber;
+}
+
+export type GetIndexerPortfolioResponse = Record<
+  IndexerPortfolioPeriod,
+  IndexerPortfolioHistory
+>;
+
+/**
  * Candlesticks
  */
 

--- a/packages/indexer-client/src/types/serverTypes.ts
+++ b/packages/indexer-client/src/types/serverTypes.ts
@@ -74,6 +74,10 @@ export interface IndexerServerPerpPricesParams {
   product_ids: number[];
 }
 
+export interface IndexerServerPortfolioParams {
+  subaccount: string;
+}
+
 export interface IndexerServerOraclePricesParams {
   product_ids: number[];
 }
@@ -276,6 +280,7 @@ export interface IndexerServerQueryRequestByType {
   oracle_price: IndexerServerOraclePricesParams;
   orders: IndexerServerOrdersParams;
   perp_prices: IndexerServerPerpPricesParams;
+  portfolio: IndexerServerPortfolioParams;
   price: IndexerServerPriceParams;
   product_snapshots: IndexerServerMultiProductsParams;
   products: IndexerServerProductsParams;
@@ -345,6 +350,30 @@ export interface IndexerServerFundingRateHistoryResponse {
   // Always ascending by timestamp.
   funding_rates: IndexerServerFundingRateHistoryEntry[];
 }
+
+export type IndexerServerPortfolioPeriod =
+  | 'day'
+  | 'week'
+  | 'month'
+  | 'allTime'
+  | 'perpDay'
+  | 'perpWeek'
+  | 'perpMonth'
+  | 'perpAllTime';
+
+// [timestamp (unix seconds), value] — both x18-free decimal strings, USDT0-denominated.
+export type IndexerServerPortfolioPoint = [string, string];
+
+export interface IndexerServerPortfolioHistory {
+  accountValueHistory: IndexerServerPortfolioPoint[];
+  pnlHistory: IndexerServerPortfolioPoint[];
+  vlm: string;
+}
+
+export type IndexerServerPortfolioResponse = [
+  IndexerServerPortfolioPeriod,
+  IndexerServerPortfolioHistory,
+][];
 
 export interface IndexerServerPerpPrices {
   product_id: number;
@@ -615,6 +644,7 @@ export interface IndexerServerQueryResponseByType {
   oracle_price: IndexerServerOraclePricesResponse;
   orders: IndexerServerOrdersResponse;
   perp_prices: IndexerServerPerpPricesResponse;
+  portfolio: IndexerServerPortfolioResponse;
   price: IndexerServerPriceResponse;
   product_snapshots: IndexerServerMultiProductsResponse;
   products: IndexerServerProductsResponse;


### PR DESCRIPTION
## Summary

Adds `getPortfolio` to `@nadohq/indexer-client`, wrapping the newly-live archive [`portfolio` endpoint](https://docs.nado.xyz/developer-resources/api/archive-indexer/portfolio).

Returns a subaccount's account-value and PnL history across all **8** series (day / week / month / allTime, each also perp-only), keyed by period for easy lookup. The value aggregates the cross-margin account plus every isolated child; the queried subaccount must be cross-margin.

## Changes
- **`types/serverTypes.ts`** — `IndexerServerPortfolio*` request/response types; registered `portfolio` in the request & response type maps.
- **`types/clientTypes.ts`** — `GetIndexerPortfolioParams`, `IndexerPortfolioPeriod`, `IndexerPortfolioPoint`, `IndexerPortfolioHistory`, and `GetIndexerPortfolioResponse` (a `Record<period, history>`, consistent with the `funding_rates` map).
- **`dataMappers.ts`** — `mapIndexerPortfolio` mapping the server's `[period, history]` tuples into the keyed record (decimal strings → `BigNumber`).
- **`IndexerBaseClient.ts`** — `getPortfolio(params)`; reachable through the composed `IndexerClient` in `@nadohq/client` with no extra wiring (same as `getFundingRateHistory`).
- **e2e** — shape test across all 8 timeframes in `subaccountQueries.test.ts`.

## Verification
- `bun run build` ✓ (6 projects)
- `bun run typecheck` ✓ (7 projects)
- `bun run lint` ✓
- `bun run test:unit` ✓ (36 passed)
- pre-commit hook (typecheck / eslint / depcruise / prettier) ✓

e2e suite not run here — it hits a live testnet archive + wallet context. The new e2e test typechecks and follows existing assertion conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)