### PR TITLE
Enhance mobile-client tests for identity and notification features

### DIFF
--- a/apps/e2e/src/mobile-client/feed.test.ts
+++ b/apps/e2e/src/mobile-client/feed.test.ts
@@ -15,8 +15,8 @@ import {
   assertArrayElements,
   assertEnumMember,
   assertHexString,
+  assertNullableString,
   assertNumber,
-  assertString,
 } from '../utils/assertions';
 import { debugPrint } from '../utils/debugPrint';
 import { delay } from '../utils/delay';
@@ -26,8 +26,8 @@ import { RunContext } from '../utils/types';
 
 void describe(
   '[mobile-client]: feed',
-  // Feed queries are currently slow server-side: an unfiltered page can take well over a minute, and even a
-  // filtered one takes ~20s. Stopgap until the backend feed query is indexed.
+  // Feed queries are still slow server-side, and an unfiltered page on a cold cache is the worst case, so
+  // these get the long timeout rather than the default.
   { timeout: TEST_TIMEOUTS.LONG },
   () => {
     let tc: RunContext;
@@ -98,8 +98,9 @@ function assertFeedPageShape(page: MobileFeedPage): void {
 function assertFeedTradeShape(trade: MobileFeedTrade, label: string): void {
   assertHexString(trade.orderDigest, `${label}.orderDigest`);
   assertHexString(trade.subaccount, `${label}.subaccount`);
-  assertString(trade.username, `${label}.username`);
-  assertString(trade.displayName, `${label}.displayName`);
+  // The feed includes unnamed public activity, so both name fields are null until a username is claimed.
+  assertNullableString(trade.username, `${label}.username`);
+  assertNullableString(trade.displayName, `${label}.displayName`);
   assert.ok(
     trade.avatarUrl === null || typeof trade.avatarUrl === 'string',
     `${label}.avatarUrl should be a string or null`,

--- a/apps/e2e/src/mobile-client/feed.test.ts
+++ b/apps/e2e/src/mobile-client/feed.test.ts
@@ -26,9 +26,7 @@ import { RunContext } from '../utils/types';
 
 void describe(
   '[mobile-client]: feed',
-  // Feed queries are still slow server-side, and an unfiltered page on a cold cache is the worst case, so
-  // these get the long timeout rather than the default.
-  { timeout: TEST_TIMEOUTS.LONG },
+  { timeout: TEST_TIMEOUTS.DEFAULT },
   () => {
     let tc: RunContext;
 

--- a/apps/e2e/src/mobile-client/identity.test.ts
+++ b/apps/e2e/src/mobile-client/identity.test.ts
@@ -5,17 +5,24 @@ import {
 } from '@nadohq/mobile-client';
 import assert from 'node:assert/strict';
 import { before, describe, test } from 'node:test';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import {
   assertBoolean,
   assertDefined,
   assertHexString,
+  assertNullableString,
   assertString,
 } from '../utils/assertions';
 import { debugPrint } from '../utils/debugPrint';
 import { delay } from '../utils/delay';
 import { getMobileSignedParams } from '../utils/getMobileSignedParams';
 import { createTestContext } from '../utils/runWithContext';
-import { TEST_DELAYS, TEST_TIMEOUTS } from '../utils/testConstants';
+import {
+  TEST_DELAYS,
+  TEST_ISOLATED_SUBACCOUNT_NAME,
+  TEST_SUBACCOUNT_NAME,
+  TEST_TIMEOUTS,
+} from '../utils/testConstants';
 import { RunContext } from '../utils/types';
 
 void describe(
@@ -51,24 +58,41 @@ void describe(
       );
     });
 
-    void test('fetches self identity without throwing', async () => {
+    void test('fetches the implicit self identity', async () => {
       const identity = await tc.mobile.getSelfIdentity(
         getMobileSignedParams(tc),
       );
       debugPrint('Self identity result', identity);
 
-      if (identity !== null) {
-        assertHexString(identity.subaccount, 'identity.subaccount');
-        assertString(identity.username, 'identity.username');
-        assertString(identity.displayName, 'identity.displayName');
-        assertBoolean(identity.privateMode, 'identity.privateMode');
-      }
+      // Every non-isolated subaccount has an implicit identity, so the test subaccount always resolves.
+      assertDefined(identity, 'identity');
+      assertHexString(identity.subaccount, 'identity.subaccount');
+      assertBoolean(identity.privateMode, 'identity.privateMode');
+      assertNullableString(identity.username, 'identity.username');
+      assertNullableString(identity.displayName, 'identity.displayName');
     });
 
-    void test('returns PROFILE_NOT_FOUND for a nonexistent username', async () => {
-      const username = `nonexistent-e2e-${Date.now()}`;
+    void test('resolves a public profile for an unclaimed subaccount', async () => {
+      // A freshly generated owner has never claimed a username, but its profile still resolves with null names.
+      const profile = await tc.mobile.getPublicProfile({
+        subaccountOwner: privateKeyToAccount(generatePrivateKey()).address,
+        subaccountName: TEST_SUBACCOUNT_NAME,
+      });
+      debugPrint('Public profile for an unclaimed subaccount', profile);
+
+      assertHexString(profile.subaccount, 'profile.subaccount');
+      assert.equal(profile.username, null);
+      assert.equal(profile.displayName, null);
+      assert.equal(profile.privateMode, false);
+    });
+
+    void test('returns PROFILE_NOT_FOUND for an isolated subaccount', async () => {
       await assertRejectsWithErrorCode(
-        () => tc.mobile.getPublicProfile({ username }),
+        () =>
+          tc.mobile.getPublicProfile({
+            subaccountOwner: tc.walletClientAddress,
+            subaccountName: TEST_ISOLATED_SUBACCOUNT_NAME,
+          }),
         MOBILE_ERROR_CODES.PROFILE_NOT_FOUND,
       );
     });
@@ -79,12 +103,8 @@ void describe(
       const existingIdentity = await tc.mobile.getSelfIdentity(identityParams);
       debugPrint('Existing identity before claim attempt', existingIdentity);
 
-      if (existingIdentity !== null) {
-        // Identity claims are permanent — never attempt to claim again once one already exists.
-        assertHexString(
-          existingIdentity.subaccount,
-          'existingIdentity.subaccount',
-        );
+      if (existingIdentity?.username != null) {
+        // Identity claims are permanent — never attempt to claim again once a username already exists.
         return;
       }
 
@@ -109,15 +129,19 @@ void describe(
       debugPrint('Identity after claim', claimedIdentity);
 
       assertDefined(claimedIdentity, 'claimedIdentity');
-      assert.equal(claimedIdentity?.displayName, displayName);
+      assert.equal(claimedIdentity.displayName, displayName);
     });
 
     void test('updates the display name and restores the original', async () => {
       const identityParams = getMobileSignedParams(tc);
 
       const identity = await tc.mobile.getSelfIdentity(identityParams);
+      assertDefined(identity, 'identity');
 
-      if (identity === null) {
+      const originalDisplayName = identity.displayName;
+
+      if (originalDisplayName === null) {
+        // Renaming needs a claimed username; a name-less implicit identity is not enough.
         await assertRejectsWithErrorCode(
           () =>
             tc.mobile.updateUsername({
@@ -129,7 +153,6 @@ void describe(
         return;
       }
 
-      const originalDisplayName = identity.displayName;
       const tempDisplayName = `E2E_${Date.now()}`;
       assert.match(tempDisplayName, MOBILE_DISPLAY_NAME_PATTERN);
 
@@ -142,7 +165,7 @@ void describe(
       const updatedIdentity = await tc.mobile.getSelfIdentity(identityParams);
       debugPrint('Identity after display name update', updatedIdentity);
       assertDefined(updatedIdentity, 'updatedIdentity');
-      assert.equal(updatedIdentity?.displayName, tempDisplayName);
+      assert.equal(updatedIdentity.displayName, tempDisplayName);
 
       await tc.mobile.updateUsername({
         ...identityParams,
@@ -153,25 +176,15 @@ void describe(
       const restoredIdentity = await tc.mobile.getSelfIdentity(identityParams);
       debugPrint('Identity after display name restore', restoredIdentity);
       assertDefined(restoredIdentity, 'restoredIdentity');
-      assert.equal(restoredIdentity?.displayName, originalDisplayName);
+      assert.equal(restoredIdentity.displayName, originalDisplayName);
     });
 
+    // Private Mode works before a username is claimed, so this needs no claimed-identity branch.
     void test('toggles private mode and restores the original value', async () => {
       const identityParams = getMobileSignedParams(tc);
 
       const identity = await tc.mobile.getSelfIdentity(identityParams);
-
-      if (identity === null) {
-        await assertRejectsWithErrorCode(
-          () =>
-            tc.mobile.setPrivateMode({
-              ...identityParams,
-              privateMode: true,
-            }),
-          MOBILE_ERROR_CODES.IDENTITY_REQUIRED,
-        );
-        return;
-      }
+      assertDefined(identity, 'identity');
 
       const originalPrivateMode = identity.privateMode;
 
@@ -184,7 +197,7 @@ void describe(
       const toggledIdentity = await tc.mobile.getSelfIdentity(identityParams);
       debugPrint('Identity after private mode toggle', toggledIdentity);
       assertDefined(toggledIdentity, 'toggledIdentity');
-      assert.equal(toggledIdentity?.privateMode, !originalPrivateMode);
+      assert.equal(toggledIdentity.privateMode, !originalPrivateMode);
 
       await tc.mobile.setPrivateMode({
         ...identityParams,
@@ -195,7 +208,7 @@ void describe(
       const restoredIdentity = await tc.mobile.getSelfIdentity(identityParams);
       debugPrint('Identity after private mode restore', restoredIdentity);
       assertDefined(restoredIdentity, 'restoredIdentity');
-      assert.equal(restoredIdentity?.privateMode, originalPrivateMode);
+      assert.equal(restoredIdentity.privateMode, originalPrivateMode);
     });
   },
 );

--- a/apps/e2e/src/mobile-client/identity.test.ts
+++ b/apps/e2e/src/mobile-client/identity.test.ts
@@ -20,6 +20,7 @@ import { createTestContext } from '../utils/runWithContext';
 import {
   TEST_DELAYS,
   TEST_ISOLATED_SUBACCOUNT_NAME,
+  TEST_SECONDARY_SUBACCOUNT_NAME,
   TEST_SUBACCOUNT_NAME,
   TEST_TIMEOUTS,
 } from '../utils/testConstants';
@@ -97,86 +98,71 @@ void describe(
       );
     });
 
-    void test('claims a username only if unclaimed, tolerating a race to IDENTITY_ALREADY_CLAIMED', async () => {
-      const identityParams = getMobileSignedParams(tc);
-
-      const existingIdentity = await tc.mobile.getSelfIdentity(identityParams);
-      debugPrint('Existing identity before claim attempt', existingIdentity);
-
-      if (existingIdentity?.username != null) {
-        // Identity claims are permanent — never attempt to claim again once a username already exists.
-        return;
-      }
-
-      const displayName = `E2E_${Date.now()}`;
-
-      try {
-        await tc.mobile.claimUsername({ ...identityParams, displayName });
-      } catch (error) {
-        if (
-          error instanceof MobileServerFailureError &&
-          error.errorCode === MOBILE_ERROR_CODES.IDENTITY_ALREADY_CLAIMED
-        ) {
-          // Another process claimed the identity between our check and this call — an acceptable race, not a failure.
-          return;
-        }
-        throw error;
-      }
-
-      await delay(TEST_DELAYS.STANDARD);
-
-      const claimedIdentity = await tc.mobile.getSelfIdentity(identityParams);
-      debugPrint('Identity after claim', claimedIdentity);
-
-      assertDefined(claimedIdentity, 'claimedIdentity');
-      assert.equal(claimedIdentity.displayName, displayName);
-    });
-
-    void test('updates the display name and restores the original', async () => {
+    // setUsername upserts, so one test covers both claiming a first username and renaming an existing one:
+    // whichever state the shared test subaccount is already in, the same call applies.
+    void test('sets the display name and restores any original', async () => {
       const identityParams = getMobileSignedParams(tc);
 
       const identity = await tc.mobile.getSelfIdentity(identityParams);
       assertDefined(identity, 'identity');
-
       const originalDisplayName = identity.displayName;
+      debugPrint('Identity before set', identity);
 
-      if (originalDisplayName === null) {
-        // Renaming needs a claimed username; a name-less implicit identity is not enough.
-        await assertRejectsWithErrorCode(
-          () =>
-            tc.mobile.updateUsername({
-              ...identityParams,
-              displayName: `E2E_${Date.now()}`,
-            }),
-          MOBILE_ERROR_CODES.IDENTITY_REQUIRED,
-        );
-        return;
-      }
+      const newDisplayName = `E2E_${Date.now()}`;
+      assert.match(newDisplayName, MOBILE_DISPLAY_NAME_PATTERN);
 
-      const tempDisplayName = `E2E_${Date.now()}`;
-      assert.match(tempDisplayName, MOBILE_DISPLAY_NAME_PATTERN);
-
-      await tc.mobile.updateUsername({
+      await tc.mobile.setUsername({
         ...identityParams,
-        displayName: tempDisplayName,
+        displayName: newDisplayName,
       });
       await delay(TEST_DELAYS.STANDARD);
 
       const updatedIdentity = await tc.mobile.getSelfIdentity(identityParams);
-      debugPrint('Identity after display name update', updatedIdentity);
+      debugPrint('Identity after set', updatedIdentity);
       assertDefined(updatedIdentity, 'updatedIdentity');
-      assert.equal(updatedIdentity.displayName, tempDisplayName);
+      assert.equal(updatedIdentity.displayName, newDisplayName);
+      assert.equal(updatedIdentity.username, newDisplayName.toLowerCase());
 
-      await tc.mobile.updateUsername({
+      if (originalDisplayName === null) {
+        // A username cannot be released once claimed, so there is nothing to restore on a first claim.
+        return;
+      }
+
+      await tc.mobile.setUsername({
         ...identityParams,
         displayName: originalDisplayName,
       });
       await delay(TEST_DELAYS.STANDARD);
 
       const restoredIdentity = await tc.mobile.getSelfIdentity(identityParams);
-      debugPrint('Identity after display name restore', restoredIdentity);
+      debugPrint('Identity after restore', restoredIdentity);
       assertDefined(restoredIdentity, 'restoredIdentity');
       assert.equal(restoredIdentity.displayName, originalDisplayName);
+    });
+
+    void test('rejects a name held by another subaccount with USERNAME_UNAVAILABLE', async () => {
+      const identityParams = getMobileSignedParams(tc);
+
+      const identity = await tc.mobile.getSelfIdentity(identityParams);
+      assertDefined(identity, 'identity');
+      const { displayName } = identity;
+
+      if (displayName === null) {
+        // No claimed name on this environment yet, so there is nothing to collide with.
+        return;
+      }
+
+      // Usernames are unique across all identities, so a second subaccount of the same owner cannot take a
+      // name the default subaccount already holds. Signing still works because the owner is unchanged.
+      await assertRejectsWithErrorCode(
+        () =>
+          tc.mobile.setUsername({
+            ...identityParams,
+            subaccountName: TEST_SECONDARY_SUBACCOUNT_NAME,
+            displayName,
+          }),
+        MOBILE_ERROR_CODES.USERNAME_UNAVAILABLE,
+      );
     });
 
     // Private Mode works before a username is claimed, so this needs no claimed-identity branch.

--- a/apps/e2e/src/mobile-client/notifications.test.ts
+++ b/apps/e2e/src/mobile-client/notifications.test.ts
@@ -84,7 +84,7 @@ void describe(
         'unregistered device should no longer be listed',
       );
 
-      // Unregister is token-authenticated and idempotent, so replaying it on the now-inactive token succeeds.
+      // Unregister is keyed by the token alone and idempotent, so replaying it on an inactive token succeeds.
       await tc.mobile.unregisterExpoToken({ expoToken });
     });
 

--- a/apps/e2e/src/mobile-client/notifications.test.ts
+++ b/apps/e2e/src/mobile-client/notifications.test.ts
@@ -1,9 +1,10 @@
 import {
+  MOBILE_ERROR_CODES,
   MobileNotificationPreferences,
   MobileServerFailureError,
 } from '@nadohq/mobile-client';
 import assert from 'node:assert/strict';
-import { before, describe, test } from 'node:test';
+import { after, before, describe, test } from 'node:test';
 import { keccak256, stringToBytes } from 'viem';
 import { assertDefined, assertString } from '../utils/assertions';
 import { debugPrint } from '../utils/debugPrint';
@@ -22,21 +23,28 @@ void describe(
   { timeout: TEST_TIMEOUTS.DEFAULT },
   () => {
     let tc: RunContext;
+    /**
+     * Preference reads and writes are authorized by possession of an active Expo push token, so the
+     * preference tests share one token registered here rather than each registering their own.
+     */
+    let preferencesExpoToken: string;
 
     before(async () => {
       await delay(TEST_DELAYS.LONG);
       tc = createTestContext();
+      preferencesExpoToken = createTestExpoToken().expoToken;
+      await tc.mobile.registerExpoToken({
+        ...getMobileSignedParams(tc),
+        expoToken: preferencesExpoToken,
+        platform: 'ios',
+        appVersion: '0.0.1-e2e',
+      });
+      await delay(TEST_DELAYS.STANDARD);
     });
 
     void test('registers, lists, and unregisters an Expo push token', async () => {
       const signedParams = getMobileSignedParams(tc);
-      // Unique per run so parallel/failed runs don't collide on the same token row.
-      const expoTokenInner = `e2e-device-${Date.now()}`;
-      const expoToken = `ExponentPushToken[${expoTokenInner}]`;
-      // The backend identifies devices by the first 8 hex chars of keccak256 over the bracket-stripped token.
-      const expectedFingerprintPrefix = keccak256(
-        stringToBytes(expoTokenInner),
-      ).slice(2, 10);
+      const { expoToken, fingerprintPrefix } = createTestExpoToken();
 
       await tc.mobile.registerExpoToken({
         ...signedParams,
@@ -51,7 +59,7 @@ void describe(
       debugPrint('Registered devices after register', devices);
 
       const registeredDevice = devices.find(
-        (device) => device.tokenFingerprintPrefix === expectedFingerprintPrefix,
+        (device) => device.tokenFingerprintPrefix === fingerprintPrefix,
       );
       assertDefined(registeredDevice, 'registeredDevice');
       assert.equal(registeredDevice?.platform, 'ios');
@@ -62,7 +70,7 @@ void describe(
         'registeredDevice.tokenFingerprintPrefix',
       );
 
-      await tc.mobile.unregisterExpoToken({ ...signedParams, expoToken });
+      await tc.mobile.unregisterExpoToken({ expoToken });
       await delay(TEST_DELAYS.STANDARD);
 
       const devicesAfterUnregister =
@@ -70,12 +78,14 @@ void describe(
       debugPrint('Registered devices after unregister', devicesAfterUnregister);
       assert.equal(
         devicesAfterUnregister.some(
-          (device) =>
-            device.tokenFingerprintPrefix === expectedFingerprintPrefix,
+          (device) => device.tokenFingerprintPrefix === fingerprintPrefix,
         ),
         false,
         'unregistered device should no longer be listed',
       );
+
+      // Unregister is token-authenticated and idempotent, so replaying it on the now-inactive token succeeds.
+      await tc.mobile.unregisterExpoToken({ expoToken });
     });
 
     void test('rejects a malformed Expo push token', async () => {
@@ -95,19 +105,39 @@ void describe(
       );
     });
 
-    void test('fetches default-shaped notification preferences', async () => {
-      const preferences = await tc.mobile.getNotificationPreferences(
-        getMobileSignedParams(tc),
+    void test('rejects a preference read for an unregistered Expo push token', async () => {
+      await assert.rejects(
+        tc.mobile.getNotificationPreferences({
+          expoToken: createTestExpoToken().expoToken,
+        }),
+        (error: unknown) => {
+          assert.ok(
+            error instanceof MobileServerFailureError,
+            'should throw MobileServerFailureError',
+          );
+          assert.equal(
+            error.errorCode,
+            MOBILE_ERROR_CODES.INVALID_EXPO_TOKEN,
+            'an unregistered token is not a valid preference credential',
+          );
+          return true;
+        },
       );
+    });
+
+    void test('fetches default-shaped notification preferences', async () => {
+      const preferences = await tc.mobile.getNotificationPreferences({
+        expoToken: preferencesExpoToken,
+      });
       debugPrint('Notification preferences', preferences);
 
       assertPreferencesShape(preferences);
     });
 
     void test('toggles a category preference and restores the original', async () => {
-      const signedParams = getMobileSignedParams(tc);
-
-      const original = await tc.mobile.getNotificationPreferences(signedParams);
+      const original = await tc.mobile.getNotificationPreferences({
+        expoToken: preferencesExpoToken,
+      });
       assertPreferencesShape(original);
 
       const toggled: MobileNotificationPreferences = {
@@ -120,12 +150,14 @@ void describe(
       };
 
       await tc.mobile.updateNotificationPreferences({
-        ...signedParams,
+        expoToken: preferencesExpoToken,
         preferences: toggled,
       });
       await delay(TEST_DELAYS.STANDARD);
 
-      const updated = await tc.mobile.getNotificationPreferences(signedParams);
+      const updated = await tc.mobile.getNotificationPreferences({
+        expoToken: preferencesExpoToken,
+      });
       debugPrint('Preferences after toggle', updated);
       assert.equal(
         updated.categories.find((category) => category.category === 'funding')
@@ -135,17 +167,39 @@ void describe(
       );
 
       await tc.mobile.updateNotificationPreferences({
-        ...signedParams,
+        expoToken: preferencesExpoToken,
         preferences: original,
       });
       await delay(TEST_DELAYS.STANDARD);
 
-      const restored = await tc.mobile.getNotificationPreferences(signedParams);
+      const restored = await tc.mobile.getNotificationPreferences({
+        expoToken: preferencesExpoToken,
+      });
       debugPrint('Preferences after restore', restored);
       assert.deepEqual(restored, original);
     });
+
+    after(async () => {
+      await tc.mobile.unregisterExpoToken({ expoToken: preferencesExpoToken });
+    });
   },
 );
+
+/**
+ * Builds an Expo push token that is unique per call, so parallel or previously failed runs never collide on
+ * the same token row, alongside the device id the backend derives from it: the first 8 hex chars of
+ * `keccak256` over the bracket-stripped token.
+ */
+function createTestExpoToken(): {
+  expoToken: string;
+  fingerprintPrefix: string;
+} {
+  const inner = `e2e-device-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return {
+    expoToken: `ExponentPushToken[${inner}]`,
+    fingerprintPrefix: keccak256(stringToBytes(inner)).slice(2, 10),
+  };
+}
 
 /**
  * Asserts the backend's preferences MVP invariants: current schema version, one entry per known category,

--- a/apps/e2e/src/utils/assertions.ts
+++ b/apps/e2e/src/utils/assertions.ts
@@ -145,6 +145,20 @@ export function assertString(value: unknown, label: string): void {
 }
 
 /**
+ * Asserts that a value is either `null` or a non-empty string, for backend fields that are genuinely absent
+ * rather than empty (e.g. an unclaimed username).
+ *
+ * @param value - The value to check.
+ * @param label - Human-readable label included in the failure message.
+ */
+export function assertNullableString(value: unknown, label: string): void {
+  if (value === null) {
+    return;
+  }
+  assertString(value, label);
+}
+
+/**
  * Asserts that a value is a non-empty string.
  *
  * @param value - The value to check.

--- a/apps/e2e/src/utils/testConstants.ts
+++ b/apps/e2e/src/utils/testConstants.ts
@@ -18,6 +18,13 @@ export const TEST_PRODUCT_ID_LIST: number[] = Object.values(TEST_PRODUCT_IDS);
 export const TEST_SUBACCOUNT_NAME = 'default';
 
 /**
+ * Subaccount name landing in the engine-created isolated namespace, which cannot own a mobile identity or
+ * public profile. A subaccount is isolated when the final three bytes of its bytes32 are ASCII `iso`; names
+ * are right-padded to 12 bytes, so the name must be exactly 12 characters and end in `iso`.
+ */
+export const TEST_ISOLATED_SUBACCOUNT_NAME = 'e2etestxxiso';
+
+/**
  * Contest IDs known to exist on the testnet leaderboard.
  * These may go stale if testnet state is reset.
  *

--- a/apps/e2e/src/utils/testConstants.ts
+++ b/apps/e2e/src/utils/testConstants.ts
@@ -25,6 +25,12 @@ export const TEST_SUBACCOUNT_NAME = 'default';
 export const TEST_ISOLATED_SUBACCOUNT_NAME = 'e2etestxxiso';
 
 /**
+ * Second subaccount of the same owner, used to exercise cross-subaccount conflicts (mobile usernames are
+ * unique globally, not per subaccount) while still signing with the one wallet the E2E suite has.
+ */
+export const TEST_SECONDARY_SUBACCOUNT_NAME = 'e2esecond';
+
+/**
  * Contest IDs known to exist on the testnet leaderboard.
  * These may go stale if testnet state is reset.
  *

--- a/packages/mobile-client/README.md
+++ b/packages/mobile-client/README.md
@@ -1,7 +1,7 @@
 # `@nadohq/mobile-client`
 
-HTTP client for the Nado mobile service API. Manages username claims, public profile lookups, privacy settings, and
-push notification devices/preferences, using EIP-712 + msgpack signed authentication.
+HTTP client for the Nado mobile service API. Manages usernames, public profile lookups, the global trade feed,
+privacy settings, and push notification devices/preferences, using EIP-712 + msgpack signed authentication.
 
 [Full SDK Documentation](https://nadohq.github.io/nado-typescript-sdk/index.html)
 
@@ -26,7 +26,10 @@ const mobile = new MobileClient({
 
 // Unsigned public lookups
 const availability = await mobile.getUsernameAvailability({ displayName: 'Alice.One' });
-const profile = await mobile.getPublicProfile({ username: 'alice.one' });
+const profile = await mobile.getPublicProfile({
+  subaccountOwner: '0x...',
+  subaccountName: 'default',
+});
 
 // Signed operations
 const identity = await mobile.getSelfIdentity({
@@ -36,7 +39,7 @@ const identity = await mobile.getSelfIdentity({
   verifyingAddr: '0x...',
 });
 
-await mobile.claimUsername({
+await mobile.setUsername({
   subaccountOwner: walletClient.account.address,
   subaccountName: 'default',
   chainId: ink.id,
@@ -49,16 +52,20 @@ await mobile.claimUsername({
 
 ### Public Queries
 
-`getUsernameAvailability`, `getPublicProfile`.
+`getUsernameAvailability`, `getPublicProfile`, `getFeed`, `getNotificationPreferences`.
+
+### Public Executes
+
+`unregisterExpoToken`, `updateNotificationPreferences`. These are authenticated by possession of an active Expo
+push token rather than a wallet signature, so they still work at logout when a signature may be unobtainable.
 
 ### Signed Queries
 
-`getSelfIdentity`, `getNotificationPreferences`, `getRegisteredDevices`.
+`getSelfIdentity`, `getRegisteredDevices`.
 
 ### Signed Executes
 
-`claimUsername`, `updateUsername`, `setPrivateMode`, `registerExpoToken`, `unregisterExpoToken`,
-`updateNotificationPreferences`.
+`setUsername`, `setPrivateMode`, `registerExpoToken`.
 
 ### Linked Signers
 

--- a/packages/mobile-client/src/MobileClient.ts
+++ b/packages/mobile-client/src/MobileClient.ts
@@ -1,4 +1,5 @@
 import {
+  subaccountToHex,
   WalletClientWithAccount,
   WalletNotProvidedError,
 } from '@nadohq/shared';
@@ -40,7 +41,10 @@ import {
 } from './types/clientTypes';
 import { MobileServerFailureError } from './types/MobileServerFailureError';
 import { MobileServerSuccessResponse } from './types/serverBaseTypes';
-import { MobileServerExecuteResult } from './types/serverExecuteTypes';
+import {
+  MobileServerExecuteResult,
+  MobileServerPublicExecuteRequest,
+} from './types/serverExecuteTypes';
 import {
   MobileServerPublicQueryRequest,
   MobileServerPublicQuerySuccessResponse,
@@ -121,27 +125,30 @@ export class MobileClient {
   }
 
   /**
-   * Looks up a subaccount's public profile by username.
+   * Looks up a subaccount's public profile. Every non-isolated subaccount resolves, with `username` and
+   * `displayName` `null` until a username is claimed. Private Mode does not hide the profile itself, only the
+   * account's activity.
    *
-   * @throws {MobileServerFailureError} With error code `PROFILE_NOT_FOUND` if no identity has claimed the
-   * username or it is invalid. Private Mode does not hide the profile itself, only the account's activity.
+   * @throws {MobileServerFailureError} With error code `PROFILE_NOT_FOUND` if the subaccount is in the
+   * engine-created isolated namespace, which cannot own a profile.
    */
   async getPublicProfile(
     params: GetMobilePublicProfileParams,
   ): Promise<MobilePublicProfile> {
     const body: MobileServerPublicQueryRequest<'profile'> = {
       type: 'profile',
-      username: params.username,
+      subaccount: subaccountToHex(params),
     };
     const data = await this.publicQuery(body);
     return mapMobilePublicProfile(data.profile);
   }
 
   /**
-   * Fetches a page of the global trade feed: public, named, perpetual trades, newest first, optionally
-   * filtered by a whole-dollar minimum notional (omitted means unfiltered). The feed is best-effort rather
-   * than authoritative history, and pagination is live (not snapshot), so deduplicate pages by
-   * {@link MobileFeedTrade.orderDigest}.
+   * Fetches a page of the global trade feed: public perpetual trades, newest first, optionally filtered by a
+   * whole-dollar minimum notional (omitted means unfiltered). Trades by subaccounts that have not claimed a
+   * username are included with `null` name fields; only private accounts are filtered out. The feed is
+   * best-effort rather than authoritative history, and pagination is live (not snapshot), so deduplicate pages
+   * by {@link MobileFeedTrade.orderDigest}.
    *
    * @throws {MobileServerFailureError} With error code `INVALID_FEED_FILTER` if `minimumNotional` or
    * `limit` is outside its allowed domain (fix the request; do not retry unchanged), or
@@ -159,13 +166,82 @@ export class MobileClient {
     return mapMobileFeedPage(data);
   }
 
+  /**
+   * Fetches the push notification preferences of the wallet that owns the given Expo push token. Possession
+   * of an active token is the credential, so no signature is required. Falls back to the backend's defaults
+   * if the wallet has never updated its preferences.
+   *
+   * @throws {MobileServerFailureError} With error code `INVALID_EXPO_TOKEN` if the token is malformed, or is
+   * not currently registered to a wallet.
+   */
+  async getNotificationPreferences(
+    params: GetMobileNotificationPreferencesParams,
+  ): Promise<MobileNotificationPreferences> {
+    const body: MobileServerPublicQueryRequest<'notification_preferences'> = {
+      type: 'notification_preferences',
+      expo_token: params.expoToken,
+    };
+    const data = await this.publicQuery(body);
+    return mapMobileNotificationPreferences(data.preferences);
+  }
+
+  /*
+  Public executes
+   */
+
+  /**
+   * Unregisters an Expo push token, stopping delivery to that device. Possession of the token is the
+   * credential, so no signature is required — which matters at logout, when a wallet signature may no longer
+   * be obtainable. Idempotent: unregistering an inactive or unknown well-formed token succeeds.
+   *
+   * A registration that commits after this call re-activates the token, so stop or await any in-flight
+   * {@link MobileClient.registerExpoToken} before unregistering.
+   *
+   * @throws {MobileServerFailureError} With error code `INVALID_EXPO_TOKEN` if the token is malformed.
+   */
+  async unregisterExpoToken(
+    params: MobileUnregisterExpoTokenParams,
+  ): Promise<MobileServerSuccessResponse> {
+    const body: MobileServerPublicExecuteRequest<'unregister_expo_token'> = {
+      type: 'unregister_expo_token',
+      expo_token: params.expoToken,
+    };
+    return this.publicExecute(body);
+  }
+
+  /**
+   * Replaces the push notification preferences of the wallet that owns the given Expo push token. Possession
+   * of an active token is the credential, so no signature is required. The backend requires `schemaVersion`
+   * of 1, exactly one entry per known category, and empty `scopes` on every entry.
+   *
+   * Writes are last-write-wins on commit order rather than ordered by a client nonce, so callers must
+   * serialize their own preference writes.
+   *
+   * @throws {MobileServerFailureError} With error code `INVALID_PREFERENCES` if those rules are violated, or
+   * `INVALID_EXPO_TOKEN` if the token is malformed or is not currently registered to a wallet.
+   */
+  async updateNotificationPreferences(
+    params: MobileUpdateNotificationPreferencesParams,
+  ): Promise<MobileServerSuccessResponse> {
+    const body: MobileServerPublicExecuteRequest<'update_preferences'> = {
+      type: 'update_preferences',
+      expo_token: params.expoToken,
+      preferences: mapMobileNotificationPreferencesToServer(params.preferences),
+    };
+    return this.publicExecute(body);
+  }
+
   /*
   Signed queries
    */
 
   /**
-   * Fetches the caller's own identity for a subaccount. Returns `null` if the subaccount has not claimed a
-   * username yet — this is normal data, not an error.
+   * Fetches the caller's own identity for a subaccount. Every non-isolated subaccount has an implicit
+   * identity, so this resolves for any valid sender with `username` and `displayName` `null` until a username
+   * is claimed.
+   *
+   * @throws {MobileServerFailureError} With error code `INVALID_IDENTITY_TARGET` if the sender is in the
+   * engine-created isolated namespace, which cannot own an identity.
    */
   async getSelfIdentity(
     params: GetMobileSelfIdentityParams,
@@ -177,22 +253,6 @@ export class MobileClient {
     );
     const data = await this.query<'self_identity'>(signedRequest);
     return data.identity ? mapMobileIdentity(data.identity) : null;
-  }
-
-  /**
-   * Fetches a wallet's push notification preferences. Falls back to the backend's defaults if the wallet has
-   * never updated its preferences.
-   */
-  async getNotificationPreferences(
-    params: GetMobileNotificationPreferencesParams,
-  ): Promise<MobileNotificationPreferences> {
-    const signedRequest = await this.getSignedRequest(
-      'notification_preferences',
-      params,
-      {},
-    );
-    const data = await this.query<'notification_preferences'>(signedRequest);
-    return mapMobileNotificationPreferences(data.preferences);
   }
 
   /**
@@ -282,41 +342,6 @@ export class MobileClient {
     return this.execute(signedRequest);
   }
 
-  /**
-   * Unregisters an Expo push token for the wallet. Idempotent — unregistering an unknown token succeeds.
-   */
-  async unregisterExpoToken(
-    params: MobileUnregisterExpoTokenParams,
-  ): Promise<MobileServerSuccessResponse> {
-    const signedRequest = await this.getSignedRequest(
-      'unregister_expo_token',
-      params,
-      { expo_token: params.expoToken },
-    );
-    return this.execute(signedRequest);
-  }
-
-  /**
-   * Replaces the wallet's push notification preferences. The backend requires `schemaVersion` of 1, exactly
-   * one entry per known category, and empty `scopes` on every entry.
-   *
-   * @throws {MobileServerFailureError} With error code `INVALID_PREFERENCES` if those rules are violated.
-   */
-  async updateNotificationPreferences(
-    params: MobileUpdateNotificationPreferencesParams,
-  ): Promise<MobileServerSuccessResponse> {
-    const signedRequest = await this.getSignedRequest(
-      'update_preferences',
-      params,
-      {
-        preferences: mapMobileNotificationPreferencesToServer(
-          params.preferences,
-        ),
-      },
-    );
-    return this.execute(signedRequest);
-  }
-
   /*
   Base Fns
    */
@@ -353,6 +378,21 @@ export class MobileClient {
 
     // checkServerStatus throws on failure responses so the cast to the success response is acceptable here
     return response.data as MobileServerPublicQuerySuccessResponse<T>;
+  }
+
+  protected async publicExecute(
+    body: MobileServerPublicExecuteRequest,
+  ): Promise<MobileServerSuccessResponse> {
+    const response = await this.axiosInstance.post<MobileServerExecuteResult>(
+      `${this.opts.url}/mobile/public_execute`,
+      body,
+    );
+
+    this.checkResponseStatus(response);
+    this.checkServerStatus(response);
+
+    // checkServerStatus catches the failure result and throws the error, so the cast to the success response is acceptable here
+    return response.data as MobileServerSuccessResponse;
   }
 
   protected async query<T extends MobileServerSignedQueryRequestType>(

--- a/packages/mobile-client/src/MobileClient.ts
+++ b/packages/mobile-client/src/MobileClient.ts
@@ -166,9 +166,9 @@ export class MobileClient {
   }
 
   /**
-   * Fetches the push notification preferences of the wallet that owns the given Expo push token. Possession
-   * of an active token is the credential, so no signature is required. Falls back to the backend's defaults
-   * if the wallet has never updated its preferences.
+   * Fetches the push notification preferences of the wallet that owns the given Expo push token. Unsigned —
+   * the token identifies the wallet on its own. Falls back to the backend's defaults if the wallet has never
+   * updated its preferences.
    *
    * @throws {MobileServerFailureError} With error code `INVALID_EXPO_TOKEN` if the token is malformed, or is
    * not currently registered to a wallet.
@@ -189,9 +189,9 @@ export class MobileClient {
    */
 
   /**
-   * Unregisters an Expo push token, stopping delivery to that device. Possession of the token is the
-   * credential, so no signature is required — which matters at logout, when a wallet signature may no longer
-   * be obtainable. Idempotent: unregistering an inactive or unknown well-formed token succeeds.
+   * Unregisters an Expo push token, stopping delivery to that device. Unsigned, so it still works at logout
+   * when a wallet signature may no longer be obtainable. Idempotent: unregistering an inactive or unknown
+   * well-formed token succeeds.
    *
    * A registration that commits after this call re-activates the token, so stop or await any in-flight
    * {@link MobileClient.registerExpoToken} before unregistering.
@@ -210,8 +210,9 @@ export class MobileClient {
 
   /**
    * Replaces the push notification preferences of the wallet that owns the given Expo push token. Possession
-   * of an active token is the credential, so no signature is required. The backend requires `schemaVersion`
-   * of 1, exactly one entry per known category, and empty `scopes` on every entry.
+   * of an active token is the credential rather than a signature, so anyone holding the token can overwrite
+   * that wallet's preferences. The backend requires `schemaVersion` of 1, exactly one entry per known
+   * category, and empty `scopes` on every entry.
    *
    * Writes are last-write-wins on commit order rather than ordered by a client nonce, so callers must
    * serialize their own preference writes.

--- a/packages/mobile-client/src/MobileClient.ts
+++ b/packages/mobile-client/src/MobileClient.ts
@@ -25,7 +25,6 @@ import {
   GetMobileRegisteredDevicesParams,
   GetMobileSelfIdentityParams,
   GetMobileUsernameAvailabilityParams,
-  MobileClaimUsernameParams,
   MobileFeedPage,
   MobileIdentity,
   MobileNotificationPreferences,
@@ -33,10 +32,10 @@ import {
   MobileRegisteredDevice,
   MobileRegisterExpoTokenParams,
   MobileSetPrivateModeParams,
+  MobileSetUsernameParams,
   MobileSignedRequestParams,
   MobileUnregisterExpoTokenParams,
   MobileUpdateNotificationPreferencesParams,
-  MobileUpdateUsernameParams,
   MobileUsernameAvailability,
 } from './types/clientTypes';
 import { MobileServerFailureError } from './types/MobileServerFailureError';
@@ -79,8 +78,8 @@ export interface MobileClientOpts {
 }
 
 /**
- * Client for the Nado mobile service API: username claims, public profile lookups, privacy settings, and
- * push notification device/preference management.
+ * Client for the Nado mobile service API: usernames, public profile lookups, the global trade feed, privacy
+ * settings, and push notification device/preference management.
  */
 export class MobileClient {
   readonly opts: MobileClientOpts;
@@ -275,32 +274,21 @@ export class MobileClient {
    */
 
   /**
-   * Claims a username for a subaccount, derived from the given display name.
+   * Sets a subaccount's username, derived from the given display name. Upserts: the same call claims a first
+   * username and renames an existing one, so callers never need to read the current identity first.
+   *
+   * @throws {MobileServerFailureError} With error code `INVALID_DISPLAY_NAME` if the display name violates
+   * `MOBILE_DISPLAY_NAME_PATTERN`, `USERNAME_UNAVAILABLE` if the derived username is reserved or already
+   * taken by another subaccount, `INVALID_IDENTITY_TARGET` if the sender is in the engine-created isolated
+   * namespace, or `STALE_IDENTITY_UPDATE` if another identity write for this subaccount committed with a
+   * later nonce (re-read the identity before retrying).
    */
-  async claimUsername(
-    params: MobileClaimUsernameParams,
+  async setUsername(
+    params: MobileSetUsernameParams,
   ): Promise<MobileServerSuccessResponse> {
-    const signedRequest = await this.getSignedRequest(
-      'claim_username',
-      params,
-      {
-        display_name: params.displayName,
-      },
-    );
-    return this.execute(signedRequest);
-  }
-
-  /**
-   * Updates the display name for a subaccount's already-claimed identity.
-   */
-  async updateUsername(
-    params: MobileUpdateUsernameParams,
-  ): Promise<MobileServerSuccessResponse> {
-    const signedRequest = await this.getSignedRequest(
-      'update_username',
-      params,
-      { display_name: params.displayName },
-    );
+    const signedRequest = await this.getSignedRequest('set_username', params, {
+      display_name: params.displayName,
+    });
     return this.execute(signedRequest);
   }
 

--- a/packages/mobile-client/src/dataMappers.ts
+++ b/packages/mobile-client/src/dataMappers.ts
@@ -41,6 +41,7 @@ export function mapMobilePublicProfile(
     subaccount: server.subaccount,
     username: server.username,
     displayName: server.display_name,
+    privateMode: server.private_mode,
   };
 }
 

--- a/packages/mobile-client/src/signing/canonicalize.ts
+++ b/packages/mobile-client/src/signing/canonicalize.ts
@@ -1,12 +1,11 @@
-import { MobileServerNotificationPreferences } from '../types/serverModelTypes';
 import { MobileSignedInner } from './types';
 
 /**
  * Rebuilds an inner payload with its keys in the backend's struct declaration order (`type` first, then the
  * remaining fields in the exact order the backend serializes them). msgpack encodes object keys in insertion
  * order and the payload hash must be reproducible regardless of how the caller constructed the object, so
- * every inner payload — and each of its sub-types — is canonicalized here before hashing. This function (with
- * {@link canonicalizeNotificationPreferences} for nested preferences) is the source of truth for that order.
+ * every inner payload — and each of its sub-types — is canonicalized here before hashing. This function is
+ * the source of truth for that order.
  */
 export function canonicalizeMobileInner(
   inner: MobileSignedInner,
@@ -28,15 +27,6 @@ export function canonicalizeMobileInner(
         locale: inner.locale,
         app_version: inner.app_version,
       };
-    case 'unregister_expo_token':
-      return { type: 'unregister_expo_token', expo_token: inner.expo_token };
-    case 'update_preferences':
-      return {
-        type: 'update_preferences',
-        preferences: canonicalizeNotificationPreferences(inner.preferences),
-      };
-    case 'notification_preferences':
-      return { type: 'notification_preferences' };
     case 'registered_devices':
       return { type: 'registered_devices' };
     default: {
@@ -45,25 +35,4 @@ export function canonicalizeMobileInner(
       );
     }
   }
-}
-
-/**
- * Rebuilds notification preferences with keys in the backend's struct declaration order, so the msgpack
- * encoding matches the backend's `rmp_serde::to_vec_named` output field-for-field.
- */
-function canonicalizeNotificationPreferences(
-  preferences: MobileServerNotificationPreferences,
-): MobileServerNotificationPreferences {
-  return {
-    schema_version: preferences.schema_version,
-    categories: preferences.categories.map((category) => ({
-      category: category.category,
-      enabled: category.enabled,
-      scopes: category.scopes.map((scope) =>
-        scope.type === 'subaccount'
-          ? { type: 'subaccount', subaccount: scope.subaccount }
-          : { type: 'product', product_id: scope.product_id },
-      ),
-    })),
-  };
 }

--- a/packages/mobile-client/src/signing/canonicalize.ts
+++ b/packages/mobile-client/src/signing/canonicalize.ts
@@ -11,10 +11,8 @@ export function canonicalizeMobileInner(
   inner: MobileSignedInner,
 ): MobileSignedInner {
   switch (inner.type) {
-    case 'claim_username':
-      return { type: 'claim_username', display_name: inner.display_name };
-    case 'update_username':
-      return { type: 'update_username', display_name: inner.display_name };
+    case 'set_username':
+      return { type: 'set_username', display_name: inner.display_name };
     case 'set_private_mode':
       return { type: 'set_private_mode', private_mode: inner.private_mode };
     case 'self_identity':

--- a/packages/mobile-client/src/signing/eip712MethodByType.ts
+++ b/packages/mobile-client/src/signing/eip712MethodByType.ts
@@ -12,8 +12,5 @@ export const MOBILE_EIP712_METHOD_BY_TYPE: Record<
   set_private_mode: 'mobile:execute_set_private_mode',
   self_identity: 'mobile:query_self_identity',
   register_expo_token: 'mobile:execute_register_expo_token',
-  unregister_expo_token: 'mobile:execute_unregister_expo_token',
-  update_preferences: 'mobile:execute_update_preferences',
-  notification_preferences: 'mobile:query_notification_preferences',
   registered_devices: 'mobile:query_registered_devices',
 };

--- a/packages/mobile-client/src/signing/eip712MethodByType.ts
+++ b/packages/mobile-client/src/signing/eip712MethodByType.ts
@@ -7,8 +7,7 @@ export const MOBILE_EIP712_METHOD_BY_TYPE: Record<
   MobileSignedInner['type'],
   string
 > = {
-  claim_username: 'mobile:execute_claim_username',
-  update_username: 'mobile:execute_update_username',
+  set_username: 'mobile:execute_set_username',
   set_private_mode: 'mobile:execute_set_private_mode',
   self_identity: 'mobile:query_self_identity',
   register_expo_token: 'mobile:execute_register_expo_token',

--- a/packages/mobile-client/src/signing/signing.test.ts
+++ b/packages/mobile-client/src/signing/signing.test.ts
@@ -28,15 +28,9 @@ const PINNED_HASHES = {
     '0x4d12a06234d751e6ddcc01d8f70836bb5b7e207e573641d1efb5aaf2b0f30d10',
   self_identity:
     '0x10e94c4502cade0a0b4d7469717bcc1d266fc6a3b7635236fa1d3600b58c9954',
-  // The three execute hashes below mirror the backend's pinned fixtures in mobile/src/api/types.rs.
+  // Mirrors the backend's pinned fixture in mobile/src/api/types.rs.
   register_expo_token:
     '0x1b9471afc9bde66f9bffd576d3326420e1bade4e16afa3a73ddc65f27155611c',
-  unregister_expo_token:
-    '0xd131071d0898c97496f3d41dfc05f30a5f82c95e550944c4fba47419ddd0ebf3',
-  update_preferences:
-    '0x071b8ac6f3d2518267dd238c8c96e15e07e0552aede3ba32383706bb05726f83',
-  notification_preferences:
-    '0x3694dda0e5732b36eb3b60da6b147ec4e35520fc54529610c69d19d722d4fe97',
   registered_devices:
     '0xe77b42e32d27f054f86d5ed52c9aac7b3eed857eb6209ee883c92f01b84d3334',
 } as const;
@@ -88,33 +82,6 @@ describe('[mobile-client]: signing (offline)', () => {
       expect(hash).toBe(PINNED_HASHES.register_expo_token);
     });
 
-    it('unregister_expo_token', () => {
-      const inner: MobileSignedInner = {
-        type: 'unregister_expo_token',
-        expo_token: 'ExponentPushToken[abcdef1234567890abcdef]',
-      };
-      const hash = getMobilePayloadHash(canonicalizeMobileInner(inner));
-      expect(hash).toBe(PINNED_HASHES.unregister_expo_token);
-    });
-
-    it('update_preferences', () => {
-      const inner: MobileSignedInner = {
-        type: 'update_preferences',
-        preferences: {
-          schema_version: 1,
-          categories: [{ category: 'order_fill', enabled: true, scopes: [] }],
-        },
-      };
-      const hash = getMobilePayloadHash(canonicalizeMobileInner(inner));
-      expect(hash).toBe(PINNED_HASHES.update_preferences);
-    });
-
-    it('notification_preferences', () => {
-      const inner: MobileSignedInner = { type: 'notification_preferences' };
-      const hash = getMobilePayloadHash(canonicalizeMobileInner(inner));
-      expect(hash).toBe(PINNED_HASHES.notification_preferences);
-    });
-
     it('registered_devices', () => {
       const inner: MobileSignedInner = { type: 'registered_devices' };
       const hash = getMobilePayloadHash(canonicalizeMobileInner(inner));
@@ -134,19 +101,19 @@ describe('[mobile-client]: signing (offline)', () => {
     expect(hash).toBe(PINNED_HASHES.set_private_mode);
   });
 
-  it('canonicalizes nested preference key order regardless of input key order', () => {
-    // Nested preference objects must also be rebuilt in the backend's struct declaration order
-    // (schema_version, categories; category, enabled, scopes) for the msgpack hash to be deterministic.
+  it('canonicalizes multi-field key order regardless of input key order', () => {
+    // register_expo_token is the only signed payload with more than one field, so it is where a caller can
+    // actually get the order wrong; canonicalizeMobileInner must rebuild it in the backend's declaration order.
     const outOfOrderInner = {
-      preferences: {
-        categories: [{ scopes: [], enabled: true, category: 'order_fill' }],
-        schema_version: 1,
-      },
-      type: 'update_preferences',
-    } as unknown as MobileSignedInner;
+      app_version: '1.2.3',
+      locale: 'en-GB',
+      platform: 'ios',
+      expo_token: 'ExponentPushToken[abcdef1234567890abcdef]',
+      type: 'register_expo_token',
+    } as MobileSignedInner;
 
     const hash = getMobilePayloadHash(canonicalizeMobileInner(outOfOrderInner));
-    expect(hash).toBe(PINNED_HASHES.update_preferences);
+    expect(hash).toBe(PINNED_HASHES.register_expo_token);
   });
 
   describe('nonce generation', () => {

--- a/packages/mobile-client/src/signing/signing.test.ts
+++ b/packages/mobile-client/src/signing/signing.test.ts
@@ -19,16 +19,15 @@ const FIXED_PRIVATE_KEY =
   '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b786907' as const;
 const FIXED_VERIFYING_ADDR = '0x0000000000000000000000000000000000000001';
 
+// `set_username`, `set_private_mode`, and `register_expo_token` mirror the backend's pinned fixtures in
+// mobile/src/api/types.rs, so a divergence here is a real wire-format break rather than a stale expectation.
 const PINNED_HASHES = {
-  claim_username:
-    '0xcfbe9e0a546f43f6d68f86b38cf260ffe079af1915800c0e6df8724ddb6f2dff',
-  update_username:
-    '0x92c3831d30de8206f9ee9d4cf29ed2a2fb1612a3b818e2e46121fc1d5eb4edb6',
+  set_username:
+    '0xb4a55d9eb0be4e5c9457761c0c34c75cf39f7c07bd170700d8dd5e9c7de4a659',
   set_private_mode:
     '0x4d12a06234d751e6ddcc01d8f70836bb5b7e207e573641d1efb5aaf2b0f30d10',
   self_identity:
     '0x10e94c4502cade0a0b4d7469717bcc1d266fc6a3b7635236fa1d3600b58c9954',
-  // Mirrors the backend's pinned fixture in mobile/src/api/types.rs.
   register_expo_token:
     '0x1b9471afc9bde66f9bffd576d3326420e1bade4e16afa3a73ddc65f27155611c',
   registered_devices:
@@ -37,22 +36,13 @@ const PINNED_HASHES = {
 
 describe('[mobile-client]: signing (offline)', () => {
   describe('pinned payload hashes', () => {
-    it('claim_username', () => {
+    it('set_username', () => {
       const inner: MobileSignedInner = {
-        type: 'claim_username',
+        type: 'set_username',
         display_name: 'Alice.One',
       };
       const hash = getMobilePayloadHash(canonicalizeMobileInner(inner));
-      expect(hash).toBe(PINNED_HASHES.claim_username);
-    });
-
-    it('update_username', () => {
-      const inner: MobileSignedInner = {
-        type: 'update_username',
-        display_name: 'Alice.Two',
-      };
-      const hash = getMobilePayloadHash(canonicalizeMobileInner(inner));
-      expect(hash).toBe(PINNED_HASHES.update_username);
+      expect(hash).toBe(PINNED_HASHES.set_username);
     });
 
     it('set_private_mode', () => {

--- a/packages/mobile-client/src/signing/types.ts
+++ b/packages/mobile-client/src/signing/types.ts
@@ -1,10 +1,7 @@
 import { WalletClientWithAccount } from '@nadohq/shared';
 import { Hex } from 'viem';
 import { MobileSignedRequestParams } from '../types/clientTypes';
-import {
-  MobileNotificationPlatform,
-  MobileServerNotificationPreferences,
-} from '../types/serverModelTypes';
+import { MobileNotificationPlatform } from '../types/serverModelTypes';
 
 /**
  * Unsigned inner payloads that can be authenticated against the mobile service API.
@@ -29,12 +26,6 @@ export type MobileSignedInner =
       locale: string | null;
       app_version: string | null;
     }
-  | { type: 'unregister_expo_token'; expo_token: string }
-  | {
-      type: 'update_preferences';
-      preferences: MobileServerNotificationPreferences;
-    }
-  | { type: 'notification_preferences' }
   | { type: 'registered_devices' };
 
 /**

--- a/packages/mobile-client/src/signing/types.ts
+++ b/packages/mobile-client/src/signing/types.ts
@@ -13,8 +13,7 @@ import { MobileNotificationPlatform } from '../types/serverModelTypes';
  * {@link canonicalizeMobileInner}, which is the source of truth. Keep the field order here in sync with it.
  */
 export type MobileSignedInner =
-  | { type: 'claim_username'; display_name: string }
-  | { type: 'update_username'; display_name: string }
+  | { type: 'set_username'; display_name: string }
   | { type: 'set_private_mode'; private_mode: boolean }
   | { type: 'self_identity' }
   | {

--- a/packages/mobile-client/src/types/clientTypes.ts
+++ b/packages/mobile-client/src/types/clientTypes.ts
@@ -8,34 +8,40 @@ import {
 } from './serverModelTypes';
 
 /**
- * A subaccount's claimed identity on the mobile service API.
+ * A subaccount's identity on the mobile service API. Every non-isolated subaccount has one implicitly, so
+ * both name fields are `null` until a username is claimed — render a local fallback label in that case and
+ * key lookups, links, and caches off `subaccount`.
  *
  * `username` and `displayName` are two representations of the same claimed name: `displayName` is what the
  * user entered (preserving casing, e.g. `Alice.One`), while `username` is the canonical, lowercased handle
- * derived from it (e.g. `alice.one`). `username` is the unique key used for profile lookups
- * ({@link MobilePublicProfile}); `displayName` is only for presentation.
+ * derived from it (e.g. `alice.one`), unique across identities.
  */
 export interface MobileIdentity {
   subaccount: Hex;
   /**
-   * Canonical, lowercased handle derived from {@link MobileIdentity.displayName}, unique per identity and
-   * used for profile lookups.
+   * Canonical, lowercased handle derived from {@link MobileIdentity.displayName}, unique across identities,
+   * or `null` if no username has been claimed.
    */
-  username: string;
+  username: string | null;
   /**
-   * User-facing name as claimed, preserving original casing. Validated against `MOBILE_DISPLAY_NAME_PATTERN`.
+   * User-facing name as claimed, preserving original casing, or `null` if no username has been claimed.
+   * Validated against `MOBILE_DISPLAY_NAME_PATTERN`.
    */
-  displayName: string;
+  displayName: string | null;
   privateMode: boolean;
 }
 
 /**
- * A subaccount's public profile, as returned by an unsigned profile lookup.
+ * A subaccount's public profile, as returned by an unsigned profile lookup. Private Mode hides the account's
+ * activity, not its profile, so `privateMode` is exposed here too.
  */
 export interface MobilePublicProfile {
   subaccount: Hex;
-  username: string;
-  displayName: string;
+  /** Canonical, lowercased handle, or `null` if no username has been claimed. */
+  username: string | null;
+  /** User-facing name as claimed, or `null` if no username has been claimed. */
+  displayName: string | null;
+  privateMode: boolean;
 }
 
 /**
@@ -65,8 +71,10 @@ export interface MobileFeedTrade {
   /** Order digest this trade is keyed by; the stable id for reconciling live pagination. */
   orderDigest: Hex;
   subaccount: Hex;
-  username: string;
-  displayName: string;
+  /** `null` when the trader has not claimed a username; render a local fallback label from `subaccount`. */
+  username: string | null;
+  /** `null` when the trader has not claimed a username; render a local fallback label from `subaccount`. */
+  displayName: string | null;
   /** Reserved for a future avatar source; `null` until one is implemented. */
   avatarUrl: string | null;
   productId: number;
@@ -151,6 +159,17 @@ export interface MobileSignedRequestParams
   extends Subaccount, SignatureParams {}
 
 /**
+ * Common params for token-authenticated notification requests, where possession of an active Expo push token
+ * is the credential instead of a wallet signature — the unsigned counterpart to
+ * {@link MobileSignedRequestParams}. The backend resolves the token's owning wallet and mutates or reads that
+ * wallet's state, so the caller never names a target.
+ */
+export interface MobileTokenAuthedRequestParams {
+  /** Expo push token, e.g. `ExponentPushToken[...]`. */
+  expoToken: string;
+}
+
+/**
  * Params for {@link MobileClient.getUsernameAvailability}.
  */
 export interface GetMobileUsernameAvailabilityParams {
@@ -160,9 +179,7 @@ export interface GetMobileUsernameAvailabilityParams {
 /**
  * Params for {@link MobileClient.getPublicProfile}.
  */
-export interface GetMobilePublicProfileParams {
-  username: string;
-}
+export type GetMobilePublicProfileParams = Subaccount;
 
 /**
  * Params for {@link MobileClient.getFeed}.
@@ -230,21 +247,20 @@ export interface MobileRegisterExpoTokenParams extends MobileSignedRequestParams
 /**
  * Params for {@link MobileClient.unregisterExpoToken}.
  */
-export interface MobileUnregisterExpoTokenParams extends MobileSignedRequestParams {
-  expoToken: string;
-}
+export type MobileUnregisterExpoTokenParams = MobileTokenAuthedRequestParams;
 
 /**
  * Params for {@link MobileClient.updateNotificationPreferences}.
  */
-export interface MobileUpdateNotificationPreferencesParams extends MobileSignedRequestParams {
+export interface MobileUpdateNotificationPreferencesParams extends MobileTokenAuthedRequestParams {
   preferences: MobileNotificationPreferences;
 }
 
 /**
  * Params for {@link MobileClient.getNotificationPreferences}.
  */
-export type GetMobileNotificationPreferencesParams = MobileSignedRequestParams;
+export type GetMobileNotificationPreferencesParams =
+  MobileTokenAuthedRequestParams;
 
 /**
  * Params for {@link MobileClient.getRegisteredDevices}.

--- a/packages/mobile-client/src/types/clientTypes.ts
+++ b/packages/mobile-client/src/types/clientTypes.ts
@@ -159,12 +159,11 @@ export interface MobileSignedRequestParams
   extends Subaccount, SignatureParams {}
 
 /**
- * Common params for token-authenticated notification requests, where possession of an active Expo push token
- * is the credential instead of a wallet signature — the unsigned counterpart to
- * {@link MobileSignedRequestParams}. The backend resolves the token's owning wallet and mutates or reads that
- * wallet's state, so the caller never names a target.
+ * Common params for the unsigned notification requests, which name their target with an Expo push token
+ * instead of a subaccount and signature — the counterpart to {@link MobileSignedRequestParams}. The backend
+ * resolves the token's owning wallet and reads or mutates that wallet's state.
  */
-export interface MobileTokenAuthedRequestParams {
+export interface MobileWithExpoTokenParams {
   /** Expo push token, e.g. `ExponentPushToken[...]`. */
   expoToken: string;
 }
@@ -241,20 +240,19 @@ export interface MobileRegisterExpoTokenParams extends MobileSignedRequestParams
 /**
  * Params for {@link MobileClient.unregisterExpoToken}.
  */
-export type MobileUnregisterExpoTokenParams = MobileTokenAuthedRequestParams;
+export type MobileUnregisterExpoTokenParams = MobileWithExpoTokenParams;
 
 /**
  * Params for {@link MobileClient.updateNotificationPreferences}.
  */
-export interface MobileUpdateNotificationPreferencesParams extends MobileTokenAuthedRequestParams {
+export interface MobileUpdateNotificationPreferencesParams extends MobileWithExpoTokenParams {
   preferences: MobileNotificationPreferences;
 }
 
 /**
  * Params for {@link MobileClient.getNotificationPreferences}.
  */
-export type GetMobileNotificationPreferencesParams =
-  MobileTokenAuthedRequestParams;
+export type GetMobileNotificationPreferencesParams = MobileWithExpoTokenParams;
 
 /**
  * Params for {@link MobileClient.getRegisteredDevices}.

--- a/packages/mobile-client/src/types/clientTypes.ts
+++ b/packages/mobile-client/src/types/clientTypes.ts
@@ -205,16 +205,10 @@ export interface GetMobileFeedParams {
 export type GetMobileSelfIdentityParams = MobileSignedRequestParams;
 
 /**
- * Params for {@link MobileClient.claimUsername}.
+ * Params for {@link MobileClient.setUsername}.
  */
-export interface MobileClaimUsernameParams extends MobileSignedRequestParams {
-  displayName: string;
-}
-
-/**
- * Params for {@link MobileClient.updateUsername}.
- */
-export interface MobileUpdateUsernameParams extends MobileSignedRequestParams {
+export interface MobileSetUsernameParams extends MobileSignedRequestParams {
+  /** User-facing name to claim, preserving casing. Must match `MOBILE_DISPLAY_NAME_PATTERN`. */
   displayName: string;
 }
 

--- a/packages/mobile-client/src/types/mobileErrorCodes.ts
+++ b/packages/mobile-client/src/types/mobileErrorCodes.ts
@@ -9,9 +9,8 @@ export const MOBILE_ERROR_CODES = {
   ...NADO_ERROR_CODES,
   INVALID_DISPLAY_NAME: 6100,
   USERNAME_UNAVAILABLE: 6101,
-  IDENTITY_ALREADY_CLAIMED: 6102,
-  IDENTITY_REQUIRED: 6103,
   INVALID_IDENTITY_TARGET: 6104,
+  /** Another identity write for the subaccount committed with a later nonce. Re-read before retrying. */
   STALE_IDENTITY_UPDATE: 6105,
   PROFILE_NOT_FOUND: 6106,
   INVALID_EXPO_TOKEN: 6200,

--- a/packages/mobile-client/src/types/serverExecuteTypes.ts
+++ b/packages/mobile-client/src/types/serverExecuteTypes.ts
@@ -2,6 +2,23 @@ import {
   MobileServerFailureResponse,
   MobileServerSuccessResponse,
 } from './serverBaseTypes';
+import {
+  MobileServerPublicExecuteRequestByType,
+  MobileServerPublicExecuteRequestType,
+} from './serverRequestTypes';
+
+/**
+ * Unsigned `public_execute` request body: a `type` discriminant flattened with its params, mirroring
+ * {@link MobileServerPublicQueryRequest}.
+ */
+export type MobileServerPublicExecuteRequest<
+  T extends MobileServerPublicExecuteRequestType =
+    MobileServerPublicExecuteRequestType,
+> = {
+  [K in MobileServerPublicExecuteRequestType]: {
+    type: K;
+  } & MobileServerPublicExecuteRequestByType[K];
+}[T];
 
 /**
  * Discriminated `execute` result union. Mobile execute routes return no payload beyond the success

--- a/packages/mobile-client/src/types/serverModelTypes.ts
+++ b/packages/mobile-client/src/types/serverModelTypes.ts
@@ -18,21 +18,24 @@ export type MobileNotificationCategory =
   | 'announcement';
 
 /**
- * Server-side public profile shape (snake_case).
+ * Server-side public profile shape (snake_case). Name fields are `null` until the subaccount claims a
+ * username.
  */
 export interface MobileServerProfile {
   subaccount: Hex;
-  username: string;
-  display_name: string;
+  username: string | null;
+  display_name: string | null;
+  private_mode: boolean;
 }
 
 /**
- * Server-side identity shape (snake_case) returned by the signed `self_identity` query.
+ * Server-side identity shape (snake_case) returned by the signed `self_identity` query. Name fields are
+ * `null` until the subaccount claims a username.
  */
 export interface MobileServerIdentity {
   subaccount: Hex;
-  username: string;
-  display_name: string;
+  username: string | null;
+  display_name: string | null;
   private_mode: boolean;
 }
 
@@ -109,8 +112,8 @@ export interface MobileServerFeedTrade {
   /** Order digest this row is keyed by; the stable id clients use to reconcile live pagination. */
   order_digest: Hex;
   subaccount: Hex;
-  username: string;
-  display_name: string;
+  username: string | null;
+  display_name: string | null;
   /** Reserved for a future avatar source; `null` until one is implemented. */
   avatar_url: string | null;
   product_id: number;
@@ -146,8 +149,8 @@ export interface MobileServerNotificationCategoryPreference {
 }
 
 /**
- * Server-side notification preferences shape (snake_case), used in both the `update_preferences` execute and
- * the `notification_preferences` query response.
+ * Server-side notification preferences shape (snake_case), used in both the `update_preferences` public
+ * execute and the `notification_preferences` public query response.
  */
 export interface MobileServerNotificationPreferences {
   /** Only `1` is accepted by the backend for the MVP. */

--- a/packages/mobile-client/src/types/serverQueryTypes.ts
+++ b/packages/mobile-client/src/types/serverQueryTypes.ts
@@ -53,15 +53,16 @@ export interface MobileServerFeedResponse {
 }
 
 /**
- * Payload of the signed `self_identity` query success response. A `null` identity means the subaccount has
- * not claimed a username yet — this is normal data, not an error.
+ * Payload of the signed `self_identity` query success response. Every non-isolated subaccount has an implicit
+ * identity, so the backend returns one for any valid sender, with `null` name fields when no username has
+ * been claimed; `identity` stays nullable to match the backend's `Option`.
  */
 export interface MobileServerSelfIdentityResponse {
   identity: MobileServerIdentity | null;
 }
 
 /**
- * Payload of the signed `notification_preferences` query success response.
+ * Payload of the `notification_preferences` public query success response.
  */
 export interface MobileServerNotificationPreferencesResponse {
   preferences: MobileServerNotificationPreferences;
@@ -84,6 +85,7 @@ export interface MobileServerPublicQueryResponseByType {
   username_availability: MobileServerUsernameAvailabilityResponse;
   profile: MobileServerProfileResponse;
   feed: MobileServerFeedResponse;
+  notification_preferences: MobileServerNotificationPreferencesResponse;
 }
 
 /**
@@ -94,7 +96,6 @@ export interface MobileServerPublicQueryResponseByType {
  */
 export interface MobileServerSignedQueryResponseByType {
   self_identity: MobileServerSelfIdentityResponse;
-  notification_preferences: MobileServerNotificationPreferencesResponse;
   registered_devices: MobileServerRegisteredDevicesResponse;
 }
 

--- a/packages/mobile-client/src/types/serverRequestTypes.ts
+++ b/packages/mobile-client/src/types/serverRequestTypes.ts
@@ -1,11 +1,13 @@
+import { Hex } from 'viem';
 import { MobileSignedInner } from '../signing/types';
+import { MobileServerNotificationPreferences } from './serverModelTypes';
 
 /**
  * Params for each unsigned `public_query`, keyed by request `type`.
  */
 export interface MobileServerPublicQueryRequestByType {
   username_availability: { display_name: string };
-  profile: { username: string };
+  profile: { subaccount: Hex };
   feed: {
     /**
      * Minimum notional as a whole-dollar JSON integer (NOT an x18 string), at least $1,000. Omitted or
@@ -20,6 +22,7 @@ export interface MobileServerPublicQueryRequestByType {
      */
     cursor?: string;
   };
+  notification_preferences: { expo_token: string };
 }
 
 /**
@@ -27,6 +30,26 @@ export interface MobileServerPublicQueryRequestByType {
  */
 export type MobileServerPublicQueryRequestType =
   keyof MobileServerPublicQueryRequestByType;
+
+/**
+ * Params for each unsigned `public_execute`, keyed by request `type`. Possession of an active Expo push token
+ * authorizes these notification-only mutations: the backend resolves the token's owning wallet and mutates
+ * its state, so no signature, sender, or nonce is sent. Ordering is the backend's last-write-wins commit
+ * order, so callers must serialize their own writes.
+ */
+export interface MobileServerPublicExecuteRequestByType {
+  unregister_expo_token: { expo_token: string };
+  update_preferences: {
+    expo_token: string;
+    preferences: MobileServerNotificationPreferences;
+  };
+}
+
+/**
+ * Discriminant `type` values for unsigned `public_execute` requests.
+ */
+export type MobileServerPublicExecuteRequestType =
+  keyof MobileServerPublicExecuteRequestByType;
 
 /**
  * Params for each signed `query`, keyed by request `type`. These queries identify the caller through the
@@ -37,7 +60,6 @@ export type MobileServerPublicQueryRequestType =
  */
 export interface MobileServerSignedQueryRequestByType {
   self_identity: Record<string, never>;
-  notification_preferences: Record<string, never>;
   registered_devices: Record<string, never>;
 }
 
@@ -59,10 +81,11 @@ export type MobileServerExecuteRequestType = Exclude<
 
 /**
  * Wire `request_type` the backend echoes on failure envelopes, prefixed by the route that produced it:
- * `public_query_*` for unsigned queries, `query_*` for signed queries, and `execute_*` for signed writes
- * (e.g. `execute_claim_username`).
+ * `public_query_*` for unsigned queries, `public_execute_*` for unsigned writes, `query_*` for signed
+ * queries, and `execute_*` for signed writes (e.g. `execute_claim_username`).
  */
 export type MobileServerRequestType =
   | `public_query_${MobileServerPublicQueryRequestType}`
+  | `public_execute_${MobileServerPublicExecuteRequestType}`
   | `query_${MobileServerSignedQueryRequestType}`
   | `execute_${MobileServerExecuteRequestType}`;

--- a/packages/mobile-client/src/types/serverRequestTypes.ts
+++ b/packages/mobile-client/src/types/serverRequestTypes.ts
@@ -82,7 +82,7 @@ export type MobileServerExecuteRequestType = Exclude<
 /**
  * Wire `request_type` the backend echoes on failure envelopes, prefixed by the route that produced it:
  * `public_query_*` for unsigned queries, `public_execute_*` for unsigned writes, `query_*` for signed
- * queries, and `execute_*` for signed writes (e.g. `execute_claim_username`).
+ * queries, and `execute_*` for signed writes (e.g. `execute_set_username`).
  */
 export type MobileServerRequestType =
   | `public_query_${MobileServerPublicQueryRequestType}`


### PR DESCRIPTION
This pull request updates and improves the mobile client E2E test suite and related utilities, focusing on better test coverage for identity, feed, and notification features. It introduces more robust handling of nullable fields, improves Expo push token management in notification tests, and clarifies the behavior of subaccounts (including isolated subaccounts). Additionally, it adds utility functions and constants to support these changes, and makes minor improvements to type imports.

**Test suite improvements and coverage:**

* [`apps/e2e/src/mobile-client/identity.test.ts`](diffhunk://#diff-ecaaf4be108a5840313fba16a1126751488db1513c10590a7783dba4345d46e5R8-R25): Refactored identity tests to use `assertNullableString` for `username` and `displayName`, added tests for unclaimed and isolated subaccounts, and clarified handling of implicit identities. Improved checks for display name and private mode updates, ensuring correct assertions and error handling. [[1]](diffhunk://#diff-ecaaf4be108a5840313fba16a1126751488db1513c10590a7783dba4345d46e5R8-R25) [[2]](diffhunk://#diff-ecaaf4be108a5840313fba16a1126751488db1513c10590a7783dba4345d46e5L54-R95) [[3]](diffhunk://#diff-ecaaf4be108a5840313fba16a1126751488db1513c10590a7783dba4345d46e5L82-R107) [[4]](diffhunk://#diff-ecaaf4be108a5840313fba16a1126751488db1513c10590a7783dba4345d46e5L112-R144) [[5]](diffhunk://#diff-ecaaf4be108a5840313fba16a1126751488db1513c10590a7783dba4345d46e5L132) [[6]](diffhunk://#diff-ecaaf4be108a5840313fba16a1126751488db1513c10590a7783dba4345d46e5L145-R168) [[7]](diffhunk://#diff-ecaaf4be108a5840313fba16a1126751488db1513c10590a7783dba4345d46e5L156-R187) [[8]](diffhunk://#diff-ecaaf4be108a5840313fba16a1126751488db1513c10590a7783dba4345d46e5L187-R200) [[9]](diffhunk://#diff-ecaaf4be108a5840313fba16a1126751488db1513c10590a7783dba4345d46e5L198-R211)

* [`apps/e2e/src/mobile-client/feed.test.ts`](diffhunk://#diff-fed02eff034f188569a0d3dcef786f65f57868f582e3a2e8a7d0576945182f20R18-L19): Updated feed shape assertions to allow for null `username` and `displayName` fields, reflecting the reality of public activity without claimed usernames. [[1]](diffhunk://#diff-fed02eff034f188569a0d3dcef786f65f57868f582e3a2e8a7d0576945182f20R18-L19) [[2]](diffhunk://#diff-fed02eff034f188569a0d3dcef786f65f57868f582e3a2e8a7d0576945182f20L101-R103)

* [`apps/e2e/src/mobile-client/notifications.test.ts`](diffhunk://#diff-d16fd1557231d27aae5f0c09e105defb9cc8d5bc06d1d3f2ccc125900f13ff0cR2-R7): Refactored notification preference tests to use a shared, uniquely generated Expo push token, improved device registration/unregistration logic, added a test for unregistered token rejection, and ensured cleanup after tests. Added a utility function to generate unique Expo tokens and their expected backend fingerprints. [[1]](diffhunk://#diff-d16fd1557231d27aae5f0c09e105defb9cc8d5bc06d1d3f2ccc125900f13ff0cR2-R7) [[2]](diffhunk://#diff-d16fd1557231d27aae5f0c09e105defb9cc8d5bc06d1d3f2ccc125900f13ff0cR26-R47) [[3]](diffhunk://#diff-d16fd1557231d27aae5f0c09e105defb9cc8d5bc06d1d3f2ccc125900f13ff0cL54-R62) [[4]](diffhunk://#diff-d16fd1557231d27aae5f0c09e105defb9cc8d5bc06d1d3f2ccc125900f13ff0cL65-R88) [[5]](diffhunk://#diff-d16fd1557231d27aae5f0c09e105defb9cc8d5bc06d1d3f2ccc125900f13ff0cL98-R140) [[6]](diffhunk://#diff-d16fd1557231d27aae5f0c09e105defb9cc8d5bc06d1d3f2ccc125900f13ff0cL123-R160) [[7]](diffhunk://#diff-d16fd1557231d27aae5f0c09e105defb9cc8d5bc06d1d3f2ccc125900f13ff0cL138-R203)

**Utility and assertion enhancements:**

* [`apps/e2e/src/utils/assertions.ts`](diffhunk://#diff-c2d77e6c81f105acaf14aaa4645d417273e02653faf2eeb396d476f9f04a2bb0R147-R160): Added `assertNullableString` to assert that a value is either `null` or a non-empty string, and updated relevant tests to use this assertion.

* [`apps/e2e/src/utils/testConstants.ts`](diffhunk://#diff-e411fcea98f1b499d6fc16d0635fc510ee5e468ab01359c9245ca0915af70fc0R20-R26): Added `TEST_ISOLATED_SUBACCOUNT_NAME` for testing isolated subaccounts, with documentation explaining its purpose and construction.

**Codebase and type improvements:**

* [`packages/mobile-client/src/MobileClient.ts`](diffhunk://#diff-158e26eb614ff5223fb3c9cee3d2f73ccc874d318b6c65291906767e52a52fabR2): Improved imports by adding `subaccountToHex` and updating type imports for better clarity and maintainability. [[1]](diffhunk://#diff-158e26eb614ff5223fb3c9cee3d2f73ccc874d318b6c65291906767e52a52fabR2) [[2]](diffhunk://#diff-158e26eb614ff5223fb3c9cee3d2f73ccc874d318b6c65291906767e52a52fabL43-R47)

**Test comments and documentation:**

* [`apps/e2e/src/mobile-client/feed.test.ts`](diffhunk://#diff-fed02eff034f188569a0d3dcef786f65f57868f582e3a2e8a7d0576945182f20L29-R30): Updated comments to clarify the reason for longer timeouts on feed queries.

These changes collectively enhance test reliability, coverage, and maintainability, especially around edge cases for user identities and notification preferences.