### PR TITLE
fix(ws): correct buildSubscriptionMessage example

### DIFF
--- a/packages/client/src/apis/ws/WebSocketSubscriptionAPI.ts
+++ b/packages/client/src/apis/ws/WebSocketSubscriptionAPI.ts
@@ -12,9 +12,15 @@ import { BaseNadoAPI } from '../base';
  * Builds subscription messages as expected by the server to send over Websocket.
  *
  * @example
- * const tradeSubscriptionParams = nadoClient.ws.subscription.buildSubscriptionParams('trade', ...);
- * const tradeSubscriptionMessage = nadoClient.ws.subscription.buildSubscriptionMessage(
- *    'subscribe', tradeSubscriptionParams);
+ * const tradeSubscriptionParams = nadoClient.ws.subscription.buildSubscriptionParams('trade', {
+ *   product_id: 1,
+ * });
+ * const tradeSubscriptionMessage =
+ *   nadoClient.ws.subscription.buildSubscriptionMessage(
+ *     1,
+ *     'subscribe',
+ *     tradeSubscriptionParams,
+ *   );
  */
 export class WebSocketSubscriptionAPI extends BaseNadoAPI {
   /**


### PR DESCRIPTION
## Summary

Fix the `@example` for `buildSubscriptionMessage` in `WebSocketSubscriptionAPI`.

The previous example did not match the actual method signature: `buildSubscriptionMessage(id, requestType, params)`. It omitted the required `id` argument and passed the remaining arguments in the wrong order.