### PR TITLE
docs(shared): fix incorrect borrow rate formula in JSDoc

### DIFF
--- a/packages/shared/src/utils/interest.ts
+++ b/packages/shared/src/utils/interest.ts
@@ -44,10 +44,10 @@ export function calcUtilizationRatio(product: SpotProduct) {
  * interest. The calculation for interest rate is as follows:
  *
  * If utilization ratio > inflection:
- *  annual rate = (1 - utilization ratio) / (1 - inflection) * interestLargeCap + interestFloor + interestSmallCap
+ * annual rate = (utilization ratio - inflection) / (1 - inflection) * interestLargeCap + interestFloor + interestSmallCap
  *
- * If utilization ratio < inflection:
- *  annual rate = utilization * interestSmallCap / inflection + utilization
+ * If utilization ratio <= inflection:
+ * annual rate = utilization ratio * interestSmallCap / inflection + interestFloor
  *
  * The returned rate is annual rate / 31536000 seconds per year.
  *


### PR DESCRIPTION
The JSDoc for `calcBorrowRatePerSecond` in `packages/shared/src/utils/interest.ts` described formulas that did not match the actual implementation.

The implementation uses:
- `(utilization - inflection) / (1 - inflection) * interestLargeCap` for the upper utilization range.
- `interestSmallCap * utilization / inflection + interestFloor` for the lower range.

The previous documentation used different formulas and did not mention that the lower branch also applies when utilization equals the inflection value.

Updated the JSDoc formulas to match the current implementation logic.